### PR TITLE
rename version to node-version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set Node.js 12.x
       uses: actions/setup-node@v1
       with:
-        version: 12.x
+        node-version: 12.x
 
     - name: npm install
       run: npm install


### PR DESCRIPTION
> Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use node-version instead