### PR TITLE
drop support of windows 2016

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ jobs:
         - ubuntu-18.04
         - ubuntu-16.04
         - windows-2019
-        - windows-2016
         - macOS-10.14
     steps:
     - name: Checkout


### PR DESCRIPTION
It will be removed on November 7

https://github.blog/changelog/2019-10-31-github-actions-windows-server-2016-r2-virtual-environment-will-be-removed-on-november-7/