### PR TITLE
update macOS environment to Catalina

### DIFF
--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   darwin:
-    runs-on: macOS-10.14
+    runs-on: macos-latest
     strategy:
       matrix:
         perl:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
         os:
         - ubuntu-18.04
         - ubuntu-16.04
-        - windows-2019
-        - macOS-10.14
+        - windows-latest
+        - macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       matrix:
         perl:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # actions-setup-perl
 
 <p align="left">
-  <a href="https://github.com/shogo82148/actions-setup-perl"><img alt="GitHub Actions status" src="https://github.com/shogo82148/actions-setup-perl/workflows/Main%20workflow/badge.svg"></a>
+  <a href="https://github.com/shogo82148/actions-setup-perl/actions"><img alt="GitHub Actions status" src="https://github.com/shogo82148/actions-setup-perl/workflows/Main%20workflow/badge.svg"></a>
 </p>
 
 This action sets by perl environment for use in actions by:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-18.04', 'macOS-10.14', 'windows-2019']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         perl: [ '5.30', '5.28' ]
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:


### PR DESCRIPTION
> The GitHub Actions macOS virtual environment has been upgraded to Catalina (v10.15). Jobs using the `macos-10.14` virtual environment will not run and must be migrated to use `macos-latest`.
> https://github.blog/changelog/2019-11-06-github-actions-macos-virtual-environment-updated-to-catalina/