### PR TITLE
disable parallel make for old perls

### DIFF
--- a/scripts/darwin/build.pl
+++ b/scripts/darwin/build.pl
@@ -5,6 +5,7 @@ use warnings;
 use strict;
 use Try::Tiny;
 use Perl::Build;
+use version 0.77 ();
 
 local $| = 1;
 
@@ -26,11 +27,19 @@ sub run {
     my $tmpdir = $ENV{RUNNER_TEMP};
 
     group "build perl $version" => sub {
+        my $jobs = 2; # from https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
+        if (version->parse("v$version") < version->parse("v5.12.0") ) {
+            # Makefiles older than v5.12.0 could break parallel make.
+            # it fixed by https://github.com/Perl/perl5/commit/0f13ebd5d71f81771c1044e2c89aff29b408bfec and
+            # https://github.com/Perl/perl5/commit/2b63e250843b907e476587f037c0784d701fca62
+            $jobs = 1;
+        }
+
         Perl::Build->install_from_cpan(
             $version => (
                 dst_path          => $install_dir,
                 configure_options => ["-de", "-Dman1dir=none", "-Dman3dir=none"],
-                jobs              => 2,
+                jobs              => $jobs,
             )
         );
     };

--- a/scripts/linux/build.pl
+++ b/scripts/linux/build.pl
@@ -5,6 +5,7 @@ use warnings;
 use strict;
 use Try::Tiny;
 use Perl::Build;
+use version 0.77 ();
 
 local $| = 1;
 
@@ -26,11 +27,19 @@ sub run {
     my $tmpdir = $ENV{RUNNER_TEMP};
 
     group "build perl $version" => sub {
+        my $jobs = 2; # from https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
+        if (version->parse("v$version") < version->parse("v5.12.0") ) {
+            # Makefiles older than v5.12.0 could break parallel make.
+            # it fixed by https://github.com/Perl/perl5/commit/0f13ebd5d71f81771c1044e2c89aff29b408bfec and
+            # https://github.com/Perl/perl5/commit/2b63e250843b907e476587f037c0784d701fca62
+            $jobs = 1;
+        }
+
         Perl::Build->install_from_cpan(
             $version => (
                 dst_path          => $install_dir,
                 configure_options => ["-de", "-Dman1dir=none", "-Dman3dir=none"],
-                jobs              => 2,
+                jobs              => $jobs,
             )
         );
     };


### PR DESCRIPTION
Makefiles older than v5.12.0 could break parallel make.
It fixed by these commits.

- https://github.com/Perl/perl5/commit/0f13ebd5d71f81771c1044e2c89aff29b408bfec
- https://github.com/Perl/perl5/commit/2b63e250843b907e476587f037c0784d701fca62