### PR TITLE
use my personal github token

### DIFF
--- a/.github/workflows/update-build-tools.yml
+++ b/.github/workflows/update-build-tools.yml
@@ -78,6 +78,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.SHOGO_GITHUB_TOKEN }}
       - name: cleanup
         run: |
           rm -f scripts/linux/cpanfile.snapshot
@@ -102,7 +104,7 @@ jobs:
 
       - name: commit
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          TOKEN: ${{ secrets.SHOGO_GITHUB_TOKEN }}
         run: |
           branch=update-$(date +"%Y-%m-%d-%H-%M-%S")
           git config --global user.name "Ichinose Shogo"
@@ -111,6 +113,6 @@ jobs:
           git add .
           git commit -m "Update cpanfile.snapshot $(date +"%Y-%m-%d %H:%M:%S")" || exit 0
           git push -u origin "$branch"
-          curl -H "Authorization: token $GITHUB_TOKEN" \
+          curl -H "Authorization: token $TOKEN" \
             -d "$(jq --arg branch $branch -n '{ "title": "Auto Update build tools", "base": "master", "head": $branch }')" \
             "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls"

--- a/.github/workflows/update-carton.yml
+++ b/.github/workflows/update-carton.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.SHOGO_GITHUB_TOKEN }}
 
       - name: update cpanfile.snapshot
         run: make update
@@ -28,7 +30,7 @@ jobs:
 
       - name: commit
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          TOKEN: ${{ secrets.SHOGO_GITHUB_TOKEN }}
         run: |
           branch=update-carton-$(date +"%Y-%m-%d-%H-%M-%S")
           git config --global user.name "Ichinose Shogo"
@@ -37,6 +39,6 @@ jobs:
           git add .
           git commit -m "Update carton $(date +"%Y-%m-%d %H:%M:%S")" || exit 0
           git push -u origin "$branch"
-          curl -H "Authorization: token $GITHUB_TOKEN" \
+          curl -H "Authorization: token $TOKEN" \
             -d "$(jq --arg branch $branch -n '{ "title": "Auto Update carton", "base": "master", "head": $branch }')" \
             "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls"

--- a/.github/workflows/update-cpanm.yml
+++ b/.github/workflows/update-cpanm.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.SHOGO_GITHUB_TOKEN }}
 
       - name: update cpanfile.snapshot
         run: make update
@@ -28,7 +30,7 @@ jobs:
 
       - name: commit
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          TOKEN: ${{ secrets.SHOGO_GITHUB_TOKEN }}
         run: |
           branch=update-cpanm-$(date +"%Y-%m-%d-%H-%M-%S")
           git config --global user.name "Ichinose Shogo"
@@ -37,6 +39,6 @@ jobs:
           git add .
           git commit -m "Update cpanm $(date +"%Y-%m-%d %H:%M:%S")" || exit 0
           git push -u origin $branch
-          curl -H "Authorization: token $GITHUB_TOKEN" \
+          curl -H "Authorization: token $TOKEN" \
             -d "$(jq --arg branch $branch -n '{ "title": "Auto Update cpanm", "base": "master", "head": $branch }')" \
             "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls"


### PR DESCRIPTION
use my personal github token instead of `github.token` for updating the dependencies.
because `github.token` doesn't trigger any GitHub Actions.
I want to run tests workflow.