### PR TITLE
add strawberry-perl-5.32.0.1-64bit

### DIFF
--- a/src/strawberry.ts
+++ b/src/strawberry.ts
@@ -28,6 +28,14 @@ interface PerlVersion {
 // availableVersions must be sorted in descending order by the version.
 const availableVersions: PerlVersion[] = [
   {
+    version: '5.32.0',
+    path: 'strawberry-perl-5.32.0.1-64bit-portable.zip'
+  },
+  {
+    version: '5.30.3',
+    path: 'strawberry-perl-5.30.3.1-64bit-portable.zip'
+  },
+  {
     version: '5.30.2',
     path: 'strawberry-perl-5.30.2.1-64bit-portable.zip'
   },


### PR DESCRIPTION
Perl 5.32.0 is not listed on http://strawberryperl.com/releases.html
but @\kms told me the download urls https://github.com/StrawberryPerl/strawberryperl.com/issues/23#issuecomment-671022737
