### PR TITLE
bundle Win32.pm

### DIFF
--- a/.github/build-openssl-darwin.sh
+++ b/.github/build-openssl-darwin.sh
@@ -25,7 +25,7 @@ echo "::group::download OpenSSL source"
 (
     set -eux
     cd "$RUNNER_TEMP"
-    curl -sSL "https://github.com/openssl/openssl/archive/OpenSSL_$OPENSSL_VERSION.tar.gz" -o openssl.tar.gz
+    curl --retry 3 -sSL "https://github.com/openssl/openssl/archive/OpenSSL_$OPENSSL_VERSION.tar.gz" -o openssl.tar.gz
 )
 echo "::endgroup::"
 

--- a/.github/build-openssl-linux.sh
+++ b/.github/build-openssl-linux.sh
@@ -24,7 +24,7 @@ echo "::group::download OpenSSL source"
 (
     set -eux
     cd "$RUNNER_TEMP"
-    curl -sSL "https://github.com/openssl/openssl/archive/OpenSSL_$OPENSSL_VERSION.tar.gz" -o openssl.tar.gz
+    curl --retry 3 -sSL "https://github.com/openssl/openssl/archive/OpenSSL_$OPENSSL_VERSION.tar.gz" -o openssl.tar.gz
 )
 echo "::endgroup::"
 

--- a/.github/build-openssl-win32.sh
+++ b/.github/build-openssl-win32.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# bundle OpenSSL for better reproducibility.
+
+set -eux
+
+OPENSSL_VERSION=1_1_1i
+ROOT=$(cd "$(dirname "$0")" && pwd)
+: "${RUNNER_TEMP:=$ROOT/working}"
+: "${RUNNER_TOOL_CACHE:=$RUNNER_TEMP/dist}"
+PERL_DIR=perl
+if [[ "x$PERL_MULTI_THREAD" != "x" ]]; then
+    PERL_DIR="$PERL_DIR-thr"
+fi
+PREFIX=$(cygpath "$RUNNER_TOOL_CACHE\perl\${{ matrix.perl }}\x64")
+
+# detect the number of CPU Core
+JOBS=$(nproc)
+
+mkdir -p "$RUNNER_TEMP"
+cd "$RUNNER_TEMP"
+
+echo "::group::download OpenSSL source"
+(
+    set -eux
+    cd "$RUNNER_TEMP"
+    curl --retry 3 -sSL "https://github.com/openssl/openssl/archive/OpenSSL_$OPENSSL_VERSION.tar.gz" -o openssl.tar.gz
+)
+echo "::endgroup::"
+
+echo "::group::extract OpenSSL source"
+(
+    set -eux
+    cd "$RUNNER_TEMP"
+    tar zxvf openssl.tar.gz
+)
+echo "::endgroup::"
+
+echo "::group::build OpenSSL"
+(
+    set -eux
+    cd "$RUNNER_TEMP/openssl-OpenSSL_$OPENSSL_VERSION"
+    ./Configure --prefix="$PREFIX" mingw64
+    make "-j$JOBS"
+    make install_sw install_ssldirs
+)
+echo "::endgroup::"

--- a/.github/build-openssl-win32.sh
+++ b/.github/build-openssl-win32.sh
@@ -2,7 +2,7 @@
 
 # bundle OpenSSL for better reproducibility.
 
-set -eux
+set -e
 
 OPENSSL_VERSION=1_1_1i
 ROOT=$(cd "$(dirname "$0")" && pwd)

--- a/.github/build-openssl-win32.sh
+++ b/.github/build-openssl-win32.sh
@@ -12,7 +12,7 @@ PERL_DIR=perl
 if [[ "x$PERL_MULTI_THREAD" != "x" ]]; then
     PERL_DIR="$PERL_DIR-thr"
 fi
-PREFIX=$(cygpath "$RUNNER_TOOL_CACHE\perl\${{ matrix.perl }}\x64")
+PREFIX=$(cygpath "$RUNNER_TOOL_CACHE\\perl\\$PERL_VERSION\\x64")
 
 # detect the number of CPU Core
 JOBS=$(nproc)

--- a/.github/build-openssl-win32.sh
+++ b/.github/build-openssl-win32.sh
@@ -8,11 +8,11 @@ OPENSSL_VERSION=1_1_1i
 ROOT=$(cd "$(dirname "$0")" && pwd)
 : "${RUNNER_TEMP:=$ROOT/working}"
 : "${RUNNER_TOOL_CACHE:=$RUNNER_TEMP/dist}"
-PERL_DIR=perl
+PERL_DIR=$PERL_VERSION
 if [[ "x$PERL_MULTI_THREAD" != "x" ]]; then
     PERL_DIR="$PERL_DIR-thr"
 fi
-PREFIX=$(cygpath "$RUNNER_TOOL_CACHE\\$PERL_DIR\\$PERL_VERSION\\x64")
+PREFIX=$(cygpath "$RUNNER_TOOL_CACHE\\perl\\$PERL_DIR\\x64")
 
 # detect the number of CPU Core
 JOBS=$(nproc)

--- a/.github/build-openssl-win32.sh
+++ b/.github/build-openssl-win32.sh
@@ -12,7 +12,7 @@ PERL_DIR=perl
 if [[ "x$PERL_MULTI_THREAD" != "x" ]]; then
     PERL_DIR="$PERL_DIR-thr"
 fi
-PREFIX=$(cygpath "$RUNNER_TOOL_CACHE\\perl\\$PERL_VERSION\\x64")
+PREFIX=$(cygpath "$RUNNER_TOOL_CACHE\\$PERL_DIR\\$PERL_VERSION\\x64")
 
 # detect the number of CPU Core
 JOBS=$(nproc)

--- a/.github/workflows/win32.yml
+++ b/.github/workflows/win32.yml
@@ -56,6 +56,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.list.outputs.matrix)}}
+    env:
+      PERL_VERSION: ${{ matrix.perl }}
     steps:
       - uses: actions/checkout@v2
 
@@ -101,7 +103,6 @@ jobs:
         shell: cmd
         run: perl build.pl
         env:
-          PERL_VERSION: ${{ matrix.perl }}
           PERL5LIB: ${{ github.workspace }}/scripts/windows/local/lib/perl5
           # PERL_DL_DEBUG: "10" # enables debugging
         working-directory: ./scripts/windows
@@ -149,6 +150,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.list.outputs.matrix)}}
+    env:
+      PERL_VERSION: ${{ matrix.perl }}
+      PERL_MULTI_THREAD: "1"
     steps:
       - uses: actions/checkout@v2
 
@@ -194,10 +198,8 @@ jobs:
         shell: cmd
         run: perl build.pl
         env:
-          PERL_VERSION: ${{ matrix.perl }}
           PERL5LIB: ${{ github.workspace }}/scripts/windows/local/lib/perl5
           # PERL_DL_DEBUG: "10" # enables debugging
-          PERL_MULTI_THREAD: "1"
         working-directory: ./scripts/windows
 
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/win32.yml
+++ b/.github/workflows/win32.yml
@@ -7,6 +7,7 @@ on:
       - "scripts/windows/**"
       - "scripts/lib/Devel/**"
       - ".github/workflows/win32.yml"
+      - ".github/build-openssl-win32.sh"
   push:
     branches:
       - "releases/*"

--- a/.github/workflows/win32.yml
+++ b/.github/workflows/win32.yml
@@ -63,15 +63,7 @@ jobs:
         with:
           install: make mingw-w64-x86_64-gcc nasm
       - name: install OpenSSL
-        run: |
-          set -eux
-          OPENSSL_VERSION=1_1_1i
-          curl --retry 3 -sSL "https://github.com/openssl/openssl/archive/OpenSSL_$OPENSSL_VERSION.tar.gz" -o openssl.tar.gz
-          tar xzf openssl.tar.gz
-          cd "openssl-OpenSSL_$OPENSSL_VERSION"
-          perl Configure --prefix="$(cygpath "$RUNNER_TOOL_CACHE\perl\${{ matrix.perl }}\x64")" mingw64
-          make "-j$(nproc)"
-          make install_sw install_ssldirs
+        run: .github/build-openssl-win32.sh
         shell: "msys2 {0}"
 
       - name: setup host perl
@@ -164,15 +156,7 @@ jobs:
         with:
           install: make mingw-w64-x86_64-gcc nasm
       - name: install OpenSSL
-        run: |
-          set -eux
-          OPENSSL_VERSION=1_1_1i
-          curl --retry 3 -sSL "https://github.com/openssl/openssl/archive/OpenSSL_$OPENSSL_VERSION.tar.gz" -o openssl.tar.gz
-          tar xzf openssl.tar.gz
-          cd "openssl-OpenSSL_$OPENSSL_VERSION"
-          perl Configure --prefix="$(cygpath "$RUNNER_TOOL_CACHE\perl\${{ matrix.perl }}-thr\x64")" mingw64
-          make "-j$(nproc)"
-          make install_sw
+        run: .github/build-openssl-win32.sh
         shell: "msys2 {0}"
 
       - name: setup host perl

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The following Perl scripts are pre-installed for convenience.
 - Net::SSLeay
 - IO::Socket::SSL
 - Mozilla::CA
+- Win32 (installed from CPAN in perl 5.8.3 or earlier. From perl 5.8.4, it is installed as a core module.)
 
 ## Actions::Core
 

--- a/scripts/windows/build.pl
+++ b/scripts/windows/build.pl
@@ -158,6 +158,9 @@ sub run {
     };
 
     group "install common CPAN modules" => sub {
+        # Win32
+        cpan_install('https://cpan.metacpan.org/authors/id/J/JD/JDB/Win32-0.54.tar.gz', 'JSON', '5.6.0', '5.8.3');
+
         # JSON
         cpan_install('https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-4.02.tar.gz', 'JSON', '5.5.3');
 

--- a/scripts/windows/build.pl
+++ b/scripts/windows/build.pl
@@ -159,7 +159,7 @@ sub run {
 
     group "install common CPAN modules" => sub {
         # Win32
-        cpan_install('https://cpan.metacpan.org/authors/id/J/JD/JDB/Win32-0.54.tar.gz', 'JSON', '5.6.0', '5.8.3');
+        cpan_install('https://cpan.metacpan.org/authors/id/J/JD/JDB/Win32-0.54.tar.gz', 'Win32', '5.6.0', '5.8.3');
 
         # JSON
         cpan_install('https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-4.02.tar.gz', 'JSON', '5.5.3');


### PR DESCRIPTION
to fix https://github.com/shogo82148/actions-setup-perl/issues/525#issuecomment-748600495

> Can't locate Win32.pm in @INC

`Win32` is available from perl v5.8.4.

```
% corelist Win32
Data for 2020-06-20
Win32 was first released with perl v5.8.4
```

I want to fatpack Win32 into cpanm, but I can't because it is an XS module.
So I'll bundle it with pre-built perl binaries.
