### PR TITLE
install Test::Harness to old perls

### DIFF
--- a/scripts/darwin/build.pl
+++ b/scripts/darwin/build.pl
@@ -156,6 +156,9 @@ sub run {
         local $ENV{NO_NETWORK_TESTING} = 1;
         local $ENV{PERL_MM_USE_DEFAULT} = 1;
         cpan_install('https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.068.tar.gz', 'IO::Socket::SSL', '5.8.1');
+
+        # Test::Harness
+        cpan_install('https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.42.tar.gz', 'Test::Harness', '5.6.0', '5.8.3');
     };
 
     group "archiving" => sub {

--- a/scripts/linux/build.pl
+++ b/scripts/linux/build.pl
@@ -155,6 +155,9 @@ sub run {
         local $ENV{NO_NETWORK_TESTING} = 1;
         local $ENV{PERL_MM_USE_DEFAULT} = 1;
         cpan_install('https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.068.tar.gz', 'IO::Socket::SSL', '5.8.1');
+
+        # Test::Harness
+        cpan_install('https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.42.tar.gz', 'Test::Harness', '5.6.0', '5.8.3');
     };
 
     group "archiving" => sub {

--- a/scripts/windows/build.pl
+++ b/scripts/windows/build.pl
@@ -214,6 +214,9 @@ sub run {
         # IO::Socket::SSL supports v5.8.1, but it doesn't work on Windows
         # https://github.com/shogo82148/actions-setup-perl/pull/480#issuecomment-735391122
         cpan_install('https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.068.tar.gz', 'IO::Socket::SSL', '5.8.7');
+
+        # Test::Harness
+        cpan_install('https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.42.tar.gz', 'Test::Harness', '5.6.0', '5.8.3');
     };
 
     group "archiving" => sub {


### PR DESCRIPTION
ref. https://github.com/shogo82148/actions-setup-perl/issues/525#issuecomment-758727294
Perl 5.6.x and 5.8.[012] has no `prove` command.
install it for convenience.