### PR TITLE
add `install-modules` option

### DIFF
--- a/.github/workflows/test-cpan-installer.yml
+++ b/.github/workflows/test-cpan-installer.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  cpanm:
+  installer:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -83,5 +83,5 @@ jobs:
         run: |
           perl -MExtUtils::MakeMaker -e 'print $ExtUtils::MakeMaker::VERSION'
 
-      - run: cpanm --help
-      - run: cpanm --version
+      - run: ${{ matrix.installer }} --help
+      - run: ${{ matrix.installer }} --version

--- a/.github/workflows/test-cpan-installer.yml
+++ b/.github/workflows/test-cpan-installer.yml
@@ -50,6 +50,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - run: npm ci
       - run: npm run build
       - run: npm run package

--- a/.github/workflows/test-cpan-installer.yml
+++ b/.github/workflows/test-cpan-installer.yml
@@ -1,4 +1,4 @@
-name: test CPAN module installer
+name: CPAN installer
 on:
   pull_request:
     paths:

--- a/.github/workflows/test-cpan-installer.yml
+++ b/.github/workflows/test-cpan-installer.yml
@@ -31,15 +31,15 @@ jobs:
           - carton
         perl:
           - "5" # latest version of Perl 5
-          - "5.8.1" # oldest version the original cpanm supports
 
+          # TODO: fix cpm
+          # - "5.8.1" # oldest version the original cpanm supports
           # TODO: @shogo82148 fix me
           # building ExtUtils::MakeMaker fails.
           # - "5.8.0"
-
-          - "5.6.2"
-          - "5.6.1" # oldest version the action supports
-
+          # TODO: fix cpm
+          # - "5.6.2"
+          # - "5.6.1" # oldest version the action supports
           # too old to work cpanm... I gave up.
           # - "5.6.0"
     steps:

--- a/.github/workflows/test-cpan-installer.yml
+++ b/.github/workflows/test-cpan-installer.yml
@@ -1,8 +1,10 @@
-name: test cpanm
+name: test CPAN module installer
 on:
   pull_request:
     paths:
       - "bin/cpanm"
+      - "bin/cpm"
+      - "bin/carton"
       - "__test__/**"
       - "src/**"
       - "package.json"
@@ -23,6 +25,10 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        installer:
+          - cpanm
+          - cpm
+          - carton
         perl:
           - "5" # latest version of Perl 5
           - "5.8.1" # oldest version the original cpanm supports
@@ -52,7 +58,7 @@ jobs:
         uses: ./
         with:
           perl-version: "${{ matrix.perl }}"
-          install-modules-with: cpanm
+          install-modules-with: "${{ matrix.installer }}"
           install-modules: |
             ExtUtils::MakeMaker
           working-directory: __test__/p5-Test-Module

--- a/.github/workflows/test-cpanm.yml
+++ b/.github/workflows/test-cpanm.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     paths:
       - "bin/cpanm"
+      - "__test__/**"
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - "action.yml"
   push:
     branches:
       - "main"
@@ -10,10 +15,14 @@ on:
 
 jobs:
   cpanm:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         perl:
           - "5" # latest version of Perl 5
           - "5.8.1" # oldest version the original cpanm supports
@@ -43,7 +52,11 @@ jobs:
         uses: ./
         with:
           perl-version: "${{ matrix.perl }}"
+          install-modules-with: cpanm
+          install-modules: |
+            ExtUtils::MakeMaker
+          working-directory: __test__/p5-Test-Module
+      - run: perl -MModule::CPANfile -e 'print $Module::CPANfile::VERSION'
 
       - run: cpanm --help
       - run: cpanm --version
-      - run: cpanm --notest ExtUtils::MakeMaker

--- a/.github/workflows/test-cpanm.yml
+++ b/.github/workflows/test-cpanm.yml
@@ -58,7 +58,7 @@ jobs:
           working-directory: __test__/p5-Test-Module
       - name: print the version of App::a2p and use it
         run: |
-          perl -MApp::a2pN -e 'print $App::a2p::VERSION'
+          perl -MApp::a2p -e 'print $App::a2p::VERSION'
           echo '$1' | a2p
 
       - name: print the version of ExtUtils::MakeMaker

--- a/.github/workflows/test-cpanm.yml
+++ b/.github/workflows/test-cpanm.yml
@@ -56,7 +56,12 @@ jobs:
           install-modules: |
             ExtUtils::MakeMaker
           working-directory: __test__/p5-Test-Module
-      - run: perl -MModule::CPANfile -e 'print $Module::CPANfile::VERSION'
+      - name: print the version of Module::CPANfile
+        run: |
+          perl -MModule::CPANfile -e 'print $Module::CPANfile::VERSION'
+      - name: print the version of ExtUtils::MakeMaker
+        run: |
+          perl -MExtUtils::MakeMaker -e 'print $ExtUtils::MakeMaker::VERSION'
 
       - run: cpanm --help
       - run: cpanm --version

--- a/.github/workflows/test-cpanm.yml
+++ b/.github/workflows/test-cpanm.yml
@@ -56,9 +56,11 @@ jobs:
           install-modules: |
             ExtUtils::MakeMaker
           working-directory: __test__/p5-Test-Module
-      - name: print the version of Module::CPANfile
+      - name: print the version of App::a2p and use it
         run: |
-          perl -MModule::CPANfile -e 'print $Module::CPANfile::VERSION'
+          perl -MApp::a2pN -e 'print $App::a2p::VERSION'
+          echo '$1' | a2p
+
       - name: print the version of ExtUtils::MakeMaker
         run: |
           perl -MExtUtils::MakeMaker -e 'print $ExtUtils::MakeMaker::VERSION'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,17 @@ jobs:
         with:
           node-version: 12.x
 
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - run: npm ci
       - run: npm run build
       - run: npm run package
@@ -107,6 +118,17 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - run: npm ci
       - run: npm run build
@@ -183,6 +205,17 @@ jobs:
         with:
           node-version: 12.x
 
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - run: npm ci
       - run: npm run build
       - run: npm run package
@@ -257,6 +290,17 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Main workflow
 on:
   pull_request:
     paths:
+      - "__test__/**"
       - "src/**"
       - "package.json"
       - "package-lock.json"
@@ -87,6 +88,14 @@ jobs:
           cpanm --help
           cpm --help
 
+      - name: install CPAN modules with cpanm
+        uses: ./
+        with:
+          perl-version: "5.30.0"
+          multi-thread: ${{ matrix.multi-thread }}
+          install-with: cpanm
+          working-directory: __test__/p5-Test-Module
+
   test-darwin:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -159,6 +168,14 @@ jobs:
           carton --help
           cpanm --help
           cpm --help
+
+      - name: install CPAN modules with cpanm
+        uses: ./
+        with:
+          perl-version: "5.30.0"
+          multi-thread: ${{ matrix.multi-thread }}
+          install-with: cpanm
+          working-directory: __test__/p5-Test-Module
 
   test-windows:
     runs-on: ${{ matrix.os }}
@@ -238,6 +255,14 @@ jobs:
           cpanm --help
           cpm --help
 
+      - name: install CPAN modules with cpanm
+        uses: ./
+        with:
+          perl-version: "5.30.0"
+          multi-thread: ${{ matrix.multi-thread }}
+          install-with: cpanm
+          working-directory: __test__/p5-Test-Module
+
   test-strawberry:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -312,6 +337,14 @@ jobs:
           carton --help
           cpanm --help
           cpm --help
+
+      - name: install CPAN modules with cpanm
+        uses: ./
+        with:
+          perl-version: "5.30.0"
+          multi-thread: ${{ matrix.multi-thread }}
+          install-with: cpanm
+          working-directory: __test__/p5-Test-Module
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,14 +88,6 @@ jobs:
           cpanm --help
           cpm --help
 
-      - name: install CPAN modules with cpanm
-        uses: ./
-        with:
-          perl-version: "5.30.0"
-          multi-thread: ${{ matrix.multi-thread }}
-          install-modules-with: cpanm
-          working-directory: __test__/p5-Test-Module
-
   test-darwin:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -168,14 +160,6 @@ jobs:
           carton --help
           cpanm --help
           cpm --help
-
-      - name: install CPAN modules with cpanm
-        uses: ./
-        with:
-          perl-version: "5.30.0"
-          multi-thread: ${{ matrix.multi-thread }}
-          install-modules-with: cpanm
-          working-directory: __test__/p5-Test-Module
 
   test-windows:
     runs-on: ${{ matrix.os }}
@@ -255,14 +239,6 @@ jobs:
           cpanm --help
           cpm --help
 
-      - name: install CPAN modules with cpanm
-        uses: ./
-        with:
-          perl-version: "5.30.0"
-          multi-thread: ${{ matrix.multi-thread }}
-          install-with: cpanm
-          working-directory: __test__/p5-Test-Module
-
   test-strawberry:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -337,14 +313,6 @@ jobs:
           carton --help
           cpanm --help
           cpm --help
-
-      - name: install CPAN modules with cpanm
-        uses: ./
-        with:
-          perl-version: "5.30.0"
-          multi-thread: ${{ matrix.multi-thread }}
-          install-modules-with: cpanm
-          working-directory: __test__/p5-Test-Module
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           perl-version: "5.30.0"
           multi-thread: ${{ matrix.multi-thread }}
-          install-with: cpanm
+          install-modules-with: cpanm
           working-directory: __test__/p5-Test-Module
 
   test-darwin:
@@ -174,7 +174,7 @@ jobs:
         with:
           perl-version: "5.30.0"
           multi-thread: ${{ matrix.multi-thread }}
-          install-with: cpanm
+          install-modules-with: cpanm
           working-directory: __test__/p5-Test-Module
 
   test-windows:
@@ -343,7 +343,7 @@ jobs:
         with:
           perl-version: "5.30.0"
           multi-thread: ${{ matrix.multi-thread }}
-          install-with: cpanm
+          install-modules-with: cpanm
           working-directory: __test__/p5-Test-Module
 
   format:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules/
 /lib/
 /__test__/runner/
+local/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ steps:
 - uses: actions/checkout@v2
 - uses: shogo82148/actions-setup-perl@v1
   with:
-    perl-version: '5.30'
+    perl-version: '5.32'
     distribution: strawberry
 - run: cpanm --installdeps .
 - run: prove -lv t
@@ -66,7 +66,7 @@ This option is available on Windows and falls back to the default customized bin
 The action works for [GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners).
 
 | Operating System | Supported Versions |
-| --- | --- | --- |
+| --- | --- |
 | Linux | `ubuntu-18.04`, `ubuntu-20.04` |
 | macOS | `macos-10.05`, `macos-11.0` |
 | Windows | `windows-2019` |
@@ -82,6 +82,9 @@ All inputs are **optional**. If not set, sensible defaults will be used.
 | `perl-version` | Specifies the Perl version to setup. Minor version and patch level can be omitted. The action uses the latest Perl version available that matches the specified value. This defaults to `5`, which results in the latest available version of Perl 5. In addition, the value `latest` is available, the actions uses the latest available version of Perl including `5`, `7` or later major versions. | `5` |
 | `distribution` | Specify the distribution to use, this is either `default` or `strawberry`. (The value `strawberry` is ignored on anything but Windows.) | `default` |
 | `multi-thread` | Enables interpreter-based threads (ithread) options (-Duseithreads). "true" and "false" are accepted. On Linux and macOS, the default value is "false" (ithread is disabled). On Windows, the default value is "true" (ithread is enable) for fork emulation. | depends on platform |
+| `install-modules-with`| install CPAN modules from your `cpanfile` with the specified installer. `cpanm`([App::cpanminus](https://metacpan.org/pod/App::cpanminus)), `cpm`([App::cpm](https://metacpan.org/pod/App::cpm)), and `carton`([Carton](https://metacpan.org/pod/Carton)) are available. By default, any CPAN modules are not installed. | Nothing |
+| `install-modules` | List of one or more CPAN modules, separated by a newline `\n` character. | Nothing |
+| `enable-modules-cache` | enable caching when install CPAN modules. | `true` |
 
 # Supported Shells
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ All inputs are **optional**. If not set, sensible defaults will be used.
 | `install-modules-with`| install CPAN modules from your `cpanfile` with the specified installer. `cpanm`([App::cpanminus](https://metacpan.org/pod/App::cpanminus)), `cpm`([App::cpm](https://metacpan.org/pod/App::cpm)), and `carton`([Carton](https://metacpan.org/pod/Carton)) are available. By default, any CPAN modules are not installed. | Nothing |
 | `install-modules` | List of one or more CPAN modules, separated by a newline `\n` character. | Nothing |
 | `enable-modules-cache` | enable caching when install CPAN modules. | `true` |
+| `working-directory` | description: working directory. | `.` |
 
 # Supported Shells
 

--- a/__test__/p5-Test-Module/cpanfile
+++ b/__test__/p5-Test-Module/cpanfile
@@ -1,0 +1,1 @@
+requires 'Module::CPANfile';

--- a/__test__/p5-Test-Module/cpanfile
+++ b/__test__/p5-Test-Module/cpanfile
@@ -1,1 +1,1 @@
-requires 'Module::CPANfile';
+requires 'App::a2p';

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ inputs:
   perl-version:
     description: "The Perl version to download (if necessary) and use. Example: 5.30.0"
     default: "5"
+    required: false
   distribution:
     description: |
       The distribution of Perl binary.
@@ -12,12 +13,28 @@ inputs:
       "default" is the custom binaries for actions-setup-perl. It is available on Linux, macOS, and Windows.
       "strawberry" is from http://strawberryperl.com/ . It is available on Windows and falls back to default on other platform.
     default: "default"
+    required: false
   multi-thread:
     description: |
-      enables multi threading options(-Duseshrplib -Duseithreads).
+      enables multi threading options(-Duseithreads).
       "true" and "false" are accepted.
       On Linux and macOS, the default value is false (multi threading is disabled).
       On Windows, this option is ignored, multi-threading is always enabled.
+    required: false
+  install-modules-with:
+    description: |
+      install CPAN modules from your cpanfile with the specified installer.
+      cpanm(App::cpanminus), cpm(App::cpm), and carton(Carton) are available.
+      By default, any CPAN modules are not installed.
+    required: false
+  install-modules:
+    description: |
+      List of one or more CPAN modules, separated by a newline \n character.
+    required: false
+  enable-modules-cache:
+    description: enable caching when install CPAN modules.
+    default: true
+    required: false
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: enable caching when install CPAN modules.
     default: true
     required: false
+  working-directory:
+    description: working directory.
+    default: "."
+    required: false
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@actions/cache": "^1.0.7",
         "@actions/core": "^1.2.7",
+        "@actions/exec": "^1.0.4",
         "@actions/tool-cache": "^1.6.1",
         "semver": "^7.3.5"
       },
@@ -24,6 +26,30 @@
         "typescript": "^4.2.4"
       }
     },
+    "node_modules/@actions/cache": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-1.0.7.tgz",
+      "integrity": "sha512-MY69kxuubqUFq84pFlu8m6Poxl5sR/xyhpC4JEvno7Yg9ASYdGizEmKgt0m8ovewpYKf15UAOcSC0hzS+DuosA==",
+      "dependencies": {
+        "@actions/core": "^1.2.6",
+        "@actions/exec": "^1.0.1",
+        "@actions/glob": "^0.1.0",
+        "@actions/http-client": "^1.0.9",
+        "@actions/io": "^1.0.1",
+        "@azure/ms-rest-js": "^2.0.7",
+        "@azure/storage-blob": "^12.1.2",
+        "semver": "^6.1.0",
+        "uuid": "^3.3.3"
+      }
+    },
+    "node_modules/@actions/cache/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@actions/core": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.7.tgz",
@@ -35,6 +61,15 @@
       "integrity": "sha512-4DPChWow9yc9W3WqEbUj8Nr86xkpyE29ZzWjXucHItclLbEW6jr80Zx4nqv18QL6KK65+cifiQZXvnqgTV6oHw==",
       "dependencies": {
         "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/glob": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.1.1.tgz",
+      "integrity": "sha512-ikM4GVZOgSGDNTjv0ECJ8AOqmDqQwtO4K1M4P465C9iikRq34+FwCjUVSwzgOYDP85qtddyWpzBw5lTub/9Xmg==",
+      "dependencies": {
+        "@actions/core": "^1.2.6",
+        "minimatch": "^3.0.4"
       }
     },
     "node_modules/@actions/http-client": {
@@ -70,6 +105,268 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.4.tgz",
+      "integrity": "sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    },
+    "node_modules/@azure/core-asynciterator-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.0.tgz",
+      "integrity": "sha512-kSDSZBL6c0CYdhb+7KuutnKGf2geeT+bCJAgccB0DD7wmNJSsQPcF7TcuoZX83B7VK4tLz/u+8sOO/CnCsYp8A==",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    },
+    "node_modules/@azure/core-http": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.4.tgz",
+      "integrity": "sha512-cNumz3ckyFZY5zWOgcTHSO7AKRVwxbodG8WfcEGcdH+ZJL3KvJEI/vN58H6xk5v3ijulU2x/WPGJqrMVvcI79A==",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-asynciterator-polyfill": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-tracing": "1.0.0-preview.11",
+        "@azure/logger": "^1.0.0",
+        "@types/node-fetch": "^2.5.0",
+        "@types/tunnel": "^0.0.1",
+        "form-data": "^3.0.0",
+        "node-fetch": "^2.6.0",
+        "process": "^0.11.10",
+        "tough-cookie": "^4.0.0",
+        "tslib": "^2.0.0",
+        "tunnel": "^0.0.6",
+        "uuid": "^8.3.0",
+        "xml2js": "^0.4.19"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/core-http/node_modules/@azure/core-tracing": {
+      "version": "1.0.0-preview.11",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.11.tgz",
+      "integrity": "sha512-frF0pJc9HTmKncVokhBxCqipjbql02DThQ1ZJ9wLi7SDMLdPAFyDI5xZNzX5guLz+/DtPkY+SGK2li9FIXqshQ==",
+      "dependencies": {
+        "@opencensus/web-types": "0.0.7",
+        "@opentelemetry/api": "1.0.0-rc.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/core-http/node_modules/@opentelemetry/api": {
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
+      "integrity": "sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/core-http/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@azure/core-http/node_modules/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@azure/core-http/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    },
+    "node_modules/@azure/core-http/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-1.0.5.tgz",
+      "integrity": "sha512-0EFCFZxARrIoLWMIRt4vuqconRVIO2Iin7nFBfJiYCCbKp5eEmxutNk8uqudPmG0XFl5YqlVh68/al/vbE5OOg==",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.2.0",
+        "@azure/core-tracing": "1.0.0-preview.11",
+        "events": "^3.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/core-lro/node_modules/@azure/core-tracing": {
+      "version": "1.0.0-preview.11",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.11.tgz",
+      "integrity": "sha512-frF0pJc9HTmKncVokhBxCqipjbql02DThQ1ZJ9wLi7SDMLdPAFyDI5xZNzX5guLz+/DtPkY+SGK2li9FIXqshQ==",
+      "dependencies": {
+        "@opencensus/web-types": "0.0.7",
+        "@opentelemetry/api": "1.0.0-rc.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/core-lro/node_modules/@opentelemetry/api": {
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
+      "integrity": "sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/core-lro/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.1.3.tgz",
+      "integrity": "sha512-his7Ah40ThEYORSpIAwuh6B8wkGwO/zG7gqVtmSE4WAJ46e36zUDXTKReUCLBDc6HmjjApQQxxcRFy5FruG79A==",
+      "dependencies": {
+        "@azure/core-asynciterator-polyfill": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.0.0-preview.10",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.10.tgz",
+      "integrity": "sha512-iIwjtMwQnsxB7cYkugMx+s4W1nfy3+pT/ceo+uW1fv4YDgYe84nh+QP0fEC9IH/3UATLSWbIBemdMHzk2APUrw==",
+      "dependencies": {
+        "@opencensus/web-types": "0.0.7",
+        "@opentelemetry/api": "^0.10.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.2.tgz",
+      "integrity": "sha512-YZNjNV0vL3nN2nedmcjQBcpCTo3oqceXmgiQtEm6fLpucjRZyQKAQruhCmCpRlB1iykqKJJ/Y8CDmT5rIE6IJw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/logger/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    },
+    "node_modules/@azure/ms-rest-js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.4.0.tgz",
+      "integrity": "sha512-kvksFowDDZ/Tqu0hkCp+oDRhh87QOlRPgx8tOIMbdbfm/Muvfdp5f0cwrgzguqT3nhmkcLzt1cvQbLTM0HmS/A==",
+      "dependencies": {
+        "@azure/core-auth": "^1.1.4",
+        "abort-controller": "^3.0.0",
+        "form-data": "^2.5.0",
+        "node-fetch": "^2.6.0",
+        "tough-cookie": "^3.0.1",
+        "tslib": "^1.10.0",
+        "tunnel": "0.0.6",
+        "uuid": "^3.3.2",
+        "xml2js": "^0.4.19"
+      }
+    },
+    "node_modules/@azure/ms-rest-js/node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/@azure/storage-blob": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.5.0.tgz",
+      "integrity": "sha512-DgoefgODst2IPkkQsNdhtYdyJgSsAZC1pEujO6aD5y7uFy5GnzhYliobSrp204jYRyK5XeJ9iiePmy/SPtTbLA==",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.2.0",
+        "@azure/core-lro": "^1.0.2",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-tracing": "1.0.0-preview.10",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^0.10.2",
+        "events": "^3.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/storage-blob/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.8.3",
@@ -949,6 +1246,33 @@
         "node": ">= 10.14.2"
       }
     },
+    "node_modules/@opencensus/web-types": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
+      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g==",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.10.2.tgz",
+      "integrity": "sha512-GtpMGd6vkzDMYcpu2t9LlhEgMy/SzBwRnz48EejlRArYqZzqSzAsKmegUK7zHgl+EOIaK9mKHhnRaQu3qw20cA==",
+      "dependencies": {
+        "@opentelemetry/context-base": "^0.10.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-base": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.10.2.tgz",
+      "integrity": "sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
@@ -1060,8 +1384,29 @@
     "node_modules/@types/node": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.1.tgz",
-      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==",
-      "dev": true
+      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA=="
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.10.tgz",
+      "integrity": "sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1086,6 +1431,14 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
+    },
+    "node_modules/@types/tunnel": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "15.0.4",
@@ -1116,6 +1469,17 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
       "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/acorn": {
       "version": "7.1.1",
@@ -1282,8 +1646,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -1414,8 +1777,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "node_modules/base": {
       "version": "0.11.2",
@@ -1498,7 +1860,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1728,7 +2089,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1745,8 +2105,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/convert-source-map": {
       "version": "1.7.0",
@@ -1956,7 +2315,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2101,6 +2459,22 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/exec-sh": {
@@ -2765,7 +3139,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4820,7 +5193,6 @@
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
       "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4829,7 +5201,6 @@
       "version": "2.1.26",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.43.0"
       },
@@ -4850,7 +5221,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4934,6 +5304,14 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -5343,6 +5721,14 @@
         "node": ">= 10"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
@@ -5359,8 +5745,7 @@
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -5376,7 +5761,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5836,6 +6220,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -6462,7 +6851,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
       "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-      "dev": true,
       "dependencies": {
         "ip-regex": "^2.1.0",
         "psl": "^1.1.28",
@@ -6520,6 +6908,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -6612,6 +7005,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/unset-value": {
@@ -6883,6 +7284,26 @@
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -6937,6 +7358,29 @@
     }
   },
   "dependencies": {
+    "@actions/cache": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-1.0.7.tgz",
+      "integrity": "sha512-MY69kxuubqUFq84pFlu8m6Poxl5sR/xyhpC4JEvno7Yg9ASYdGizEmKgt0m8ovewpYKf15UAOcSC0hzS+DuosA==",
+      "requires": {
+        "@actions/core": "^1.2.6",
+        "@actions/exec": "^1.0.1",
+        "@actions/glob": "^0.1.0",
+        "@actions/http-client": "^1.0.9",
+        "@actions/io": "^1.0.1",
+        "@azure/ms-rest-js": "^2.0.7",
+        "@azure/storage-blob": "^12.1.2",
+        "semver": "^6.1.0",
+        "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
     "@actions/core": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.7.tgz",
@@ -6948,6 +7392,15 @@
       "integrity": "sha512-4DPChWow9yc9W3WqEbUj8Nr86xkpyE29ZzWjXucHItclLbEW6jr80Zx4nqv18QL6KK65+cifiQZXvnqgTV6oHw==",
       "requires": {
         "@actions/io": "^1.0.1"
+      }
+    },
+    "@actions/glob": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.1.1.tgz",
+      "integrity": "sha512-ikM4GVZOgSGDNTjv0ECJ8AOqmDqQwtO4K1M4P465C9iikRq34+FwCjUVSwzgOYDP85qtddyWpzBw5lTub/9Xmg==",
+      "requires": {
+        "@actions/core": "^1.2.6",
+        "minimatch": "^3.0.4"
       }
     },
     "@actions/http-client": {
@@ -6980,6 +7433,236 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
+    "@azure/abort-controller": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.4.tgz",
+      "integrity": "sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@azure/core-asynciterator-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
+    },
+    "@azure/core-auth": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.0.tgz",
+      "integrity": "sha512-kSDSZBL6c0CYdhb+7KuutnKGf2geeT+bCJAgccB0DD7wmNJSsQPcF7TcuoZX83B7VK4tLz/u+8sOO/CnCsYp8A==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@azure/core-http": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.4.tgz",
+      "integrity": "sha512-cNumz3ckyFZY5zWOgcTHSO7AKRVwxbodG8WfcEGcdH+ZJL3KvJEI/vN58H6xk5v3ijulU2x/WPGJqrMVvcI79A==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-asynciterator-polyfill": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-tracing": "1.0.0-preview.11",
+        "@azure/logger": "^1.0.0",
+        "@types/node-fetch": "^2.5.0",
+        "@types/tunnel": "^0.0.1",
+        "form-data": "^3.0.0",
+        "node-fetch": "^2.6.0",
+        "process": "^0.11.10",
+        "tough-cookie": "^4.0.0",
+        "tslib": "^2.0.0",
+        "tunnel": "^0.0.6",
+        "uuid": "^8.3.0",
+        "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "@azure/core-tracing": {
+          "version": "1.0.0-preview.11",
+          "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.11.tgz",
+          "integrity": "sha512-frF0pJc9HTmKncVokhBxCqipjbql02DThQ1ZJ9wLi7SDMLdPAFyDI5xZNzX5guLz+/DtPkY+SGK2li9FIXqshQ==",
+          "requires": {
+            "@opencensus/web-types": "0.0.7",
+            "@opentelemetry/api": "1.0.0-rc.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@opentelemetry/api": {
+          "version": "1.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
+          "integrity": "sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ=="
+        },
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "tough-cookie": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+          "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+          "requires": {
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.1.2"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@azure/core-lro": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-1.0.5.tgz",
+      "integrity": "sha512-0EFCFZxARrIoLWMIRt4vuqconRVIO2Iin7nFBfJiYCCbKp5eEmxutNk8uqudPmG0XFl5YqlVh68/al/vbE5OOg==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.2.0",
+        "@azure/core-tracing": "1.0.0-preview.11",
+        "events": "^3.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@azure/core-tracing": {
+          "version": "1.0.0-preview.11",
+          "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.11.tgz",
+          "integrity": "sha512-frF0pJc9HTmKncVokhBxCqipjbql02DThQ1ZJ9wLi7SDMLdPAFyDI5xZNzX5guLz+/DtPkY+SGK2li9FIXqshQ==",
+          "requires": {
+            "@opencensus/web-types": "0.0.7",
+            "@opentelemetry/api": "1.0.0-rc.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@opentelemetry/api": {
+          "version": "1.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz",
+          "integrity": "sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ=="
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@azure/core-paging": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.1.3.tgz",
+      "integrity": "sha512-his7Ah40ThEYORSpIAwuh6B8wkGwO/zG7gqVtmSE4WAJ46e36zUDXTKReUCLBDc6HmjjApQQxxcRFy5FruG79A==",
+      "requires": {
+        "@azure/core-asynciterator-polyfill": "^1.0.0"
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.0.0-preview.10",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.10.tgz",
+      "integrity": "sha512-iIwjtMwQnsxB7cYkugMx+s4W1nfy3+pT/ceo+uW1fv4YDgYe84nh+QP0fEC9IH/3UATLSWbIBemdMHzk2APUrw==",
+      "requires": {
+        "@opencensus/web-types": "0.0.7",
+        "@opentelemetry/api": "^0.10.2",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@azure/logger": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.2.tgz",
+      "integrity": "sha512-YZNjNV0vL3nN2nedmcjQBcpCTo3oqceXmgiQtEm6fLpucjRZyQKAQruhCmCpRlB1iykqKJJ/Y8CDmT5rIE6IJw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@azure/ms-rest-js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.4.0.tgz",
+      "integrity": "sha512-kvksFowDDZ/Tqu0hkCp+oDRhh87QOlRPgx8tOIMbdbfm/Muvfdp5f0cwrgzguqT3nhmkcLzt1cvQbLTM0HmS/A==",
+      "requires": {
+        "@azure/core-auth": "^1.1.4",
+        "abort-controller": "^3.0.0",
+        "form-data": "^2.5.0",
+        "node-fetch": "^2.6.0",
+        "tough-cookie": "^3.0.1",
+        "tslib": "^1.10.0",
+        "tunnel": "0.0.6",
+        "uuid": "^3.3.2",
+        "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@azure/storage-blob": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.5.0.tgz",
+      "integrity": "sha512-DgoefgODst2IPkkQsNdhtYdyJgSsAZC1pEujO6aD5y7uFy5GnzhYliobSrp204jYRyK5XeJ9iiePmy/SPtTbLA==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.2.0",
+        "@azure/core-lro": "^1.0.2",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-tracing": "1.0.0-preview.10",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^0.10.2",
+        "events": "^3.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
         }
       }
     },
@@ -7769,6 +8452,24 @@
         "chalk": "^4.0.0"
       }
     },
+    "@opencensus/web-types": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
+      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g=="
+    },
+    "@opentelemetry/api": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.10.2.tgz",
+      "integrity": "sha512-GtpMGd6vkzDMYcpu2t9LlhEgMy/SzBwRnz48EejlRArYqZzqSzAsKmegUK7zHgl+EOIaK9mKHhnRaQu3qw20cA==",
+      "requires": {
+        "@opentelemetry/context-base": "^0.10.2"
+      }
+    },
+    "@opentelemetry/context-base": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.10.2.tgz",
+      "integrity": "sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw=="
+    },
     "@sinonjs/commons": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
@@ -7880,8 +8581,28 @@
     "@types/node": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.1.tgz",
-      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==",
-      "dev": true
+      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA=="
+    },
+    "@types/node-fetch": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.10.tgz",
+      "integrity": "sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -7906,6 +8627,14 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
+    },
+    "@types/tunnel": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "15.0.4",
@@ -7933,6 +8662,14 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "acorn": {
       "version": "7.1.1",
@@ -8060,8 +8797,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -8170,8 +8906,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -8241,7 +8976,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -8433,7 +9167,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -8447,8 +9180,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -8624,8 +9356,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -8732,6 +9463,16 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -9267,8 +10008,7 @@
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
-      "dev": true
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -10979,14 +11719,12 @@
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
-      "dev": true
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
       "version": "2.1.26",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-      "dev": true,
       "requires": {
         "mime-db": "1.43.0"
       }
@@ -11001,7 +11739,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11069,6 +11806,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -11385,6 +12127,11 @@
         "react-is": "^17.0.1"
       }
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
     "prompts": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
@@ -11398,8 +12145,7 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "pump": {
       "version": "3.0.0",
@@ -11414,8 +12160,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -11798,6 +12543,11 @@
           }
         }
       }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "5.0.1",
@@ -12312,7 +13062,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
       "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-      "dev": true,
       "requires": {
         "ip-regex": "^2.1.0",
         "psl": "^1.1.28",
@@ -12353,6 +13102,11 @@
           "dev": true
         }
       }
+    },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tunnel": {
       "version": "0.0.6",
@@ -12421,6 +13175,11 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -12648,6 +13407,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   },
   "homepage": "https://github.com/shogo82148/actions-setup-perl#readme",
   "dependencies": {
+    "@actions/cache": "^1.0.7",
     "@actions/core": "^1.2.7",
+    "@actions/exec": "^1.0.4",
     "@actions/tool-cache": "^1.6.1",
     "semver": "^7.3.5"
   },

--- a/src/cpan-installer.ts
+++ b/src/cpan-installer.ts
@@ -180,8 +180,20 @@ async function installWithCpm(opt: Options): Promise<void> {
 }
 
 async function installWithCarton(opt: Options): Promise<void> {
+  const carton = path.join(__dirname, '..', 'bin', 'carton');
+  const workingDirectory = path.join(process.cwd(), opt.working_directory || '.');
+  const execOpt = {
+    cwd: workingDirectory
+  };
+  const args = ['install'];
+  await exec.exec(carton, [...args], execOpt);
   if (opt.install_modules) {
-    // TODO
+    const cpanm = path.join(__dirname, '..', 'bin', 'cpanm');
+    const modules = opt.install_modules.split('\n').map(s => s.trim());
+    const args = ['--local-lib-contained', 'local', '--notest'];
+    if (core.isDebug()) {
+      args.push('--verbose');
+    }
+    await exec.exec(cpanm, [...args, ...modules], execOpt);
   }
-  throw new Error('not implemented');
 }

--- a/src/cpan-installer.ts
+++ b/src/cpan-installer.ts
@@ -67,6 +67,10 @@ export async function install(opt: Options): Promise<void> {
   // install
   await installer(opt);
 
+  // configure environment values
+  core.addPath(path.join(cachePath, 'bin'));
+  core.exportVariable('PERL5LIB', path.join(cachePath, 'lib', 'perl5') + path.delimiter + process.env['PERL5LIB']);
+
   return;
 }
 

--- a/src/cpan-installer.ts
+++ b/src/cpan-installer.ts
@@ -124,6 +124,7 @@ function hashString(s: string): string {
 }
 
 async function installWithCpanm(opt: Options): Promise<void> {
+  const cpanm = path.join(__dirname, '..', 'bin', 'cpanm');
   const workingDirectory = path.join(process.cwd(), opt.working_directory || '.');
   const execOpt = {
     cwd: workingDirectory
@@ -132,10 +133,10 @@ async function installWithCpanm(opt: Options): Promise<void> {
   if (core.isDebug()) {
     args.push('--verbose');
   }
-  await exec.exec('cpanm', [...args, '--installdeps', '.'], execOpt);
+  await exec.exec(cpanm, [...args, '--installdeps', '.'], execOpt);
   if (opt.install_modules) {
     const modules = opt.install_modules.split('\n');
-    await exec.exec('cpanm', [...args, ...modules], execOpt);
+    await exec.exec(cpanm, [...args, ...modules], execOpt);
   }
 }
 async function installWithCpm(opt: Options): Promise<void> {

--- a/src/cpan-installer.ts
+++ b/src/cpan-installer.ts
@@ -96,7 +96,7 @@ export async function install(opt: Options): Promise<void> {
 }
 
 async function cacheKey(opt: Options): Promise<string> {
-  let key = 'setup-perl-module-cache-v1-';
+  let key = 'setup-perl-module-cache-v2-';
   key += await digestOfPerlVersion();
   key += '-' + (opt.install_modules_with || 'unknown');
   return key;
@@ -183,4 +183,5 @@ async function installWithCarton(opt: Options): Promise<void> {
   if (opt.install_modules) {
     // TODO
   }
+  throw new Error('not implemented');
 }

--- a/src/cpan-installer.ts
+++ b/src/cpan-installer.ts
@@ -135,7 +135,7 @@ async function installWithCpanm(opt: Options): Promise<void> {
   }
   await exec.exec(cpanm, [...args, '--installdeps', '.'], execOpt);
   if (opt.install_modules) {
-    const modules = opt.install_modules.split('\n');
+    const modules = opt.install_modules.split('\n').map(s => s.trim());
     await exec.exec(cpanm, [...args, ...modules], execOpt);
   }
 }

--- a/src/cpan-installer.ts
+++ b/src/cpan-installer.ts
@@ -161,11 +161,24 @@ async function installWithCpanm(opt: Options): Promise<void> {
     await exec.exec(cpanm, [...args, ...modules], execOpt);
   }
 }
+
 async function installWithCpm(opt: Options): Promise<void> {
+  const cpm = path.join(__dirname, '..', 'bin', 'cpm');
+  const workingDirectory = path.join(process.cwd(), opt.working_directory || '.');
+  const execOpt = {
+    cwd: workingDirectory
+  };
+  const args = ['install'];
+  if (core.isDebug()) {
+    args.push('--verbose');
+  }
+  await exec.exec(cpm, [...args], execOpt);
   if (opt.install_modules) {
-    // TODO
+    const modules = opt.install_modules.split('\n').map(s => s.trim());
+    await exec.exec(cpm, [...args, ...modules], execOpt);
   }
 }
+
 async function installWithCarton(opt: Options): Promise<void> {
   if (opt.install_modules) {
     // TODO

--- a/src/cpan-installer.ts
+++ b/src/cpan-installer.ts
@@ -41,7 +41,7 @@ export async function install(opt: Options): Promise<void> {
 
   const cachePath = path.join(workingDirectory, 'local');
 
-  const baseKey = await cacheKey();
+  const baseKey = await cacheKey(opt);
   const cpanfileKey = await hashFiles(
     path.join(workingDirectory, 'cpanfile'),
     path.join(workingDirectory, 'cpanfile.snapshot')
@@ -74,9 +74,10 @@ export async function install(opt: Options): Promise<void> {
   return;
 }
 
-async function cacheKey(): Promise<string> {
+async function cacheKey(opt: Options): Promise<string> {
   let key = 'setup-perl-module-cache-v1-';
   key += await digestOfPerlVersion();
+  key += '-' + (opt.install_modules_with || 'unknown');
   return key;
 }
 

--- a/src/cpan-installer.ts
+++ b/src/cpan-installer.ts
@@ -113,11 +113,23 @@ function hashString(s: string): string {
 }
 
 async function installWithCpanm(opt: Options): Promise<void> {
-  const args = ['--local-lib-contained', 'local', '--notest', '--installdeps', '.'];
+  const args = ['--local-lib-contained', 'local', '--notest'];
   if (core.isDebug()) {
     args.push('--verbose');
   }
-  await exec.exec('cpanm', args);
+  await exec.exec('cpanm', [...args, '--installdeps', '.']);
+  if (opt.install_modules) {
+    const modules = opt.install_modules.split('\n');
+    await exec.exec('cpanm', [...args, ...modules]);
+  }
 }
-async function installWithCpm(opt: Options): Promise<void> {}
-async function installWithCarton(opt: Options): Promise<void> {}
+async function installWithCpm(opt: Options): Promise<void> {
+  if (opt.install_modules) {
+    // TODO
+  }
+}
+async function installWithCarton(opt: Options): Promise<void> {
+  if (opt.install_modules) {
+    // TODO
+  }
+}

--- a/src/cpan-installer.ts
+++ b/src/cpan-installer.ts
@@ -116,7 +116,8 @@ async function digestOfPerlVersion(opt: Options): Promise<string> {
       stdout: (data: Buffer) => {
         hash.update(data);
       }
-    }
+    },
+    env: {}
   });
   hash.end();
   return hash.digest('hex');

--- a/src/cpan-installer.ts
+++ b/src/cpan-installer.ts
@@ -174,7 +174,7 @@ async function installWithCpm(opt: Options): Promise<void> {
   const execOpt = {
     cwd: workingDirectory
   };
-  const args = [cpm, 'install'];
+  const args = [cpm, 'install', '--show-build-log-on-failure'];
   if (core.isDebug()) {
     args.push('--verbose');
   }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -9,6 +9,10 @@ import * as tcp from './tool-cache-port';
 const osPlat = os.platform();
 const osArch = os.arch();
 
+export interface Result {
+  installedPath: string;
+}
+
 async function getAvailableVersions(): Promise<string[]> {
   return new Promise<string[]>((resolve, reject) => {
     fs.readFile(path.join(__dirname, '..', 'versions', `${osPlat}.json`), (err, data) => {
@@ -37,7 +41,7 @@ async function determineVersion(version: string): Promise<string> {
   throw new Error('unable to get latest version');
 }
 
-export async function getPerl(version: string, thread: boolean) {
+export async function getPerl(version: string, thread: boolean): Promise<Result> {
   const selected = await determineVersion(version);
 
   // check cache
@@ -55,6 +59,10 @@ export async function getPerl(version: string, thread: boolean) {
   // prepend the tools path. instructs the agent to prepend for future tasks
   //
   core.addPath(bin);
+
+  return {
+    installedPath: toolPath
+  };
 }
 
 async function acquirePerl(version: string, thread: boolean): Promise<string> {

--- a/src/setup-perl.ts
+++ b/src/setup-perl.ts
@@ -2,6 +2,8 @@ import * as core from '@actions/core';
 import * as installer from './installer';
 import * as path from 'path';
 import * as strawberry from './strawberry';
+import * as utils from './utils';
+import * as cpan from './cpan-installer';
 
 async function run() {
   try {
@@ -10,71 +12,56 @@ async function run() {
     const multiThread = core.getInput('multi-thread');
     const version = core.getInput('perl-version');
 
-    let thread: boolean;
-    if (platform === 'win32') {
-      thread = parseBoolean(multiThread || 'true');
-      if (dist === 'strawberry' && !thread) {
-        core.warning('non-thread Strawberry Perl is not provided.');
+    core.group('install perl', async () => {
+      let thread: boolean;
+      if (platform === 'win32') {
+        thread = utils.parseBoolean(multiThread || 'true');
+        if (dist === 'strawberry' && !thread) {
+          core.warning('non-thread Strawberry Perl is not provided.');
+        }
+      } else {
+        if (dist === 'strawberry') {
+          core.warning(
+            'The strawberry distribution is not available on this platform. fallback to the default distribution.'
+          );
+          dist = 'default';
+        }
+        thread = utils.parseBoolean(multiThread || 'false');
       }
-    } else {
-      if (dist === 'strawberry') {
-        core.warning(
-          'The strawberry distribution is not available on this platform. fallback to the default distribution.'
-        );
-        dist = 'default';
+
+      if (version) {
+        switch (dist) {
+          case 'strawberry':
+            await strawberry.getPerl(version);
+            break;
+          case 'default':
+            await installer.getPerl(version, thread);
+            break;
+          default:
+            throw new Error(`unknown distribution: ${dist}`);
+        }
       }
-      thread = parseBoolean(multiThread || 'false');
-    }
 
-    if (version) {
-      switch (dist) {
-        case 'strawberry':
-          await strawberry.getPerl(version);
-          break;
-        case 'default':
-          await installer.getPerl(version, thread);
-          break;
-        default:
-          throw new Error(`unknown distribution: ${dist}`);
-      }
-    }
+      const matchersPath = path.join(__dirname, '..', '.github');
+      console.log(`##[add-matcher]${path.join(matchersPath, 'perl.json')}`);
 
-    const matchersPath = path.join(__dirname, '..', '.github');
-    console.log(`##[add-matcher]${path.join(matchersPath, 'perl.json')}`);
+      // for pre-installed scripts
+      core.addPath(path.join(__dirname, '..', 'bin'));
 
-    // for pre-installed scripts
-    core.addPath(path.join(__dirname, '..', 'bin'));
+      // for pre-installed modules
+      core.exportVariable('PERL5LIB', path.join(__dirname, '..', 'scripts', 'lib'));
+    });
 
-    // for pre-installed modules
-    core.exportVariable('PERL5LIB', path.join(__dirname, '..', 'scripts', 'lib'));
+    core.group('install CPAN modules', async () => {
+      await cpan.install({
+        install_modules_with: core.getInput('install-modules-with'),
+        install_modules: core.getInput('install-modules'),
+        enable_modules_cache: core.getInput('enable-modules-cache')
+      });
+    });
   } catch (error) {
     core.setFailed(error.message);
   }
-}
-
-function parseBoolean(s: string): boolean {
-  // YAML 1.0 compatible boolean values
-  switch (s) {
-    case 'y':
-    case 'Y':
-    case 'yes':
-    case 'Yes':
-    case 'YES':
-    case 'true':
-    case 'True':
-    case 'TRUE':
-      return true;
-    case 'n':
-    case 'N':
-    case 'no':
-    case 'No':
-    case 'NO':
-    case 'false':
-    case 'False':
-    case 'FALSE':
-      return false;
-  }
-  throw `invalid boolean value: ${s}`;
 }
 
 run();

--- a/src/setup-perl.ts
+++ b/src/setup-perl.ts
@@ -12,6 +12,7 @@ async function run() {
     const multiThread = core.getInput('multi-thread');
     const version = core.getInput('perl-version');
 
+    let result: installer.Result;
     core.group('install perl', async () => {
       let thread: boolean;
       if (platform === 'win32') {
@@ -32,10 +33,10 @@ async function run() {
       if (version) {
         switch (dist) {
           case 'strawberry':
-            await strawberry.getPerl(version);
+            result = await strawberry.getPerl(version);
             break;
           case 'default':
-            await installer.getPerl(version, thread);
+            result = await installer.getPerl(version, thread);
             break;
           default:
             throw new Error(`unknown distribution: ${dist}`);
@@ -54,6 +55,7 @@ async function run() {
 
     core.group('install CPAN modules', async () => {
       await cpan.install({
+        toolPath: result.installedPath,
         install_modules_with: core.getInput('install-modules-with'),
         install_modules: core.getInput('install-modules'),
         enable_modules_cache: core.getInput('enable-modules-cache'),

--- a/src/setup-perl.ts
+++ b/src/setup-perl.ts
@@ -13,7 +13,7 @@ async function run() {
     const version = core.getInput('perl-version');
 
     let result: installer.Result;
-    core.group('install perl', async () => {
+    await core.group('install perl', async () => {
       let thread: boolean;
       if (platform === 'win32') {
         thread = utils.parseBoolean(multiThread || 'true');
@@ -53,7 +53,7 @@ async function run() {
       core.exportVariable('PERL5LIB', path.join(__dirname, '..', 'scripts', 'lib'));
     });
 
-    core.group('install CPAN modules', async () => {
+    await core.group('install CPAN modules', async () => {
       await cpan.install({
         toolPath: result.installedPath,
         install_modules_with: core.getInput('install-modules-with'),

--- a/src/setup-perl.ts
+++ b/src/setup-perl.ts
@@ -56,7 +56,8 @@ async function run() {
       await cpan.install({
         install_modules_with: core.getInput('install-modules-with'),
         install_modules: core.getInput('install-modules'),
-        enable_modules_cache: core.getInput('enable-modules-cache')
+        enable_modules_cache: core.getInput('enable-modules-cache'),
+        working_directory: core.getInput('working-directory')
       });
     });
   } catch (error) {

--- a/src/strawberry.ts
+++ b/src/strawberry.ts
@@ -10,6 +10,10 @@ interface PerlVersion {
   path: string;
 }
 
+export interface Result {
+  installedPath: string;
+}
+
 // NOTE:
 // I don't know why, but 5.18.3 is missing.
 // {
@@ -53,7 +57,7 @@ async function determineVersion(version: string): Promise<PerlVersion> {
   throw new Error('unable to get latest version');
 }
 
-export async function getPerl(version: string) {
+export async function getPerl(version: string): Promise<Result> {
   // check cache
   const selected = await determineVersion(version);
   let toolPath: string;
@@ -79,6 +83,10 @@ export async function getPerl(version: string) {
   core.addPath(path.join(toolPath, 'c', 'bin'));
   core.addPath(path.join(toolPath, 'perl', 'bin'));
   core.addPath(path.join(toolPath, 'perl', 'site', 'bin'));
+
+  return {
+    installedPath: path.join(toolPath, 'perl')
+  };
 }
 
 async function acquirePerl(version: PerlVersion): Promise<string> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,24 @@
+export function parseBoolean(s: string): boolean {
+  // YAML 1.0 compatible boolean values
+  switch (s) {
+    case 'y':
+    case 'Y':
+    case 'yes':
+    case 'Yes':
+    case 'YES':
+    case 'true':
+    case 'True':
+    case 'TRUE':
+      return true;
+    case 'n':
+    case 'N':
+    case 'no':
+    case 'No':
+    case 'NO':
+    case 'false':
+    case 'False':
+    case 'FALSE':
+      return false;
+  }
+  throw `invalid boolean value: ${s}`;
+}


### PR DESCRIPTION
related with https://github.com/shogo82148/actions-setup-perl/issues/684

There are many concerns which means using actions/cache is never enough for caching CPAN modules (e.g., incomplete cache key, cleaning old modules when restoring from another key, correctly hashing the lockfile if not checked in, OS versions, ABI compatibility, etc.)
So, actions-setup-perl should provides installing and caching CPAN modules.

Actually, the [setup-ruby action](https://github.com/ruby/setup-ruby) provides installing and caching gem option.
https://github.com/ruby/setup-ruby#caching-bundle-install-automatically
