### PR TITLE
trim args for cpan installer

### DIFF
--- a/src/cpan-installer.ts
+++ b/src/cpan-installer.ts
@@ -248,5 +248,9 @@ function splitArgs(args: string | null): string[] {
   if (!args) {
     return [];
   }
+  args = args.trim();
+  if (args === '') {
+    return [];
+  }
   return args.split(/\s+/);
 }


### PR DESCRIPTION
folded style strings end with '\n'.
https://yaml.org/spec/1.2/spec.html#id2796251

wo need to remove it.