### PR TITLE
bump IO-Socket-SSL v2.071

### DIFF
--- a/scripts/darwin/build.pl
+++ b/scripts/darwin/build.pl
@@ -160,7 +160,7 @@ sub run {
         # IO::Socket::SSL
         local $ENV{NO_NETWORK_TESTING} = 1;
         local $ENV{PERL_MM_USE_DEFAULT} = 1;
-        cpan_install('https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.070.tar.gz', 'IO::Socket::SSL', '5.8.1');
+        cpan_install('https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.071.tar.gz', 'IO::Socket::SSL', '5.8.1');
 
         # Test::Harness
         cpan_install('https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.42.tar.gz', 'Test::Harness', '5.6.0', '5.8.3');

--- a/scripts/linux/build.pl
+++ b/scripts/linux/build.pl
@@ -159,7 +159,7 @@ sub run {
         # IO::Socket::SSL
         local $ENV{NO_NETWORK_TESTING} = 1;
         local $ENV{PERL_MM_USE_DEFAULT} = 1;
-        cpan_install('https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.070.tar.gz', 'IO::Socket::SSL', '5.8.1');
+        cpan_install('https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.071.tar.gz', 'IO::Socket::SSL', '5.8.1');
 
         # Test::Harness
         cpan_install('https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.42.tar.gz', 'Test::Harness', '5.6.0', '5.8.3');

--- a/scripts/windows/build.pl
+++ b/scripts/windows/build.pl
@@ -221,7 +221,7 @@ sub run {
         # NOTE:
         # IO::Socket::SSL supports v5.8.1, but it doesn't work on Windows
         # https://github.com/shogo82148/actions-setup-perl/pull/480#issuecomment-735391122
-        cpan_install('https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.070.tar.gz', 'IO::Socket::SSL', '5.8.7');
+        cpan_install('https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.071.tar.gz', 'IO::Socket::SSL', '5.8.7');
 
         # Test::Harness
         cpan_install('https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.42.tar.gz', 'Test::Harness', '5.6.0', '5.8.3');


### PR DESCRIPTION
ref. https://metacpan.org/release/SULLR/IO-Socket-SSL-2.071