### PR TITLE
versionFile should fallback to .perl-version, not .python-version

### DIFF
--- a/src/setup-perl.ts
+++ b/src/setup-perl.ts
@@ -106,7 +106,7 @@ async function resolveVersionInput(): Promise<string> {
     return version;
   }
 
-  const versionFilePath = path.join(process.env.GITHUB_WORKSPACE || "", versionFile || ".python-version");
+  const versionFilePath = path.join(process.env.GITHUB_WORKSPACE || "", versionFile || ".perl-version");
   version = await fs.readFile(versionFilePath, "utf8");
   core.info(`Resolved ${versionFile} as ${version}`);
   return version;


### PR DESCRIPTION
Related:
- https://github.com/shogo82148/actions-setup-perl/issues/1359
- https://github.com/shogo82148/actions-setup-perl/pull/1367

Thank you for implementing #1359, but I found a mistake in the diff when retrieving the versionFilePath.

If versionFile is not specified, `.python-version` would accidentally be used for the version, so this should be `.perl-version` .