### PR TITLE
use the default test runner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,6 @@ updates:
       # update too often, ignore patch releases
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-patch"]
-    groups:
-      jest-monorepo:
-        patterns:
-          - jest
-          - jest-circus
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,9 @@
 module.exports = {
   clearMocks: true,
-  moduleFileExtensions: ['js', 'ts'],
-  testEnvironment: 'node',
-  testMatch: ['**/*.test.ts'],
-  testRunner: 'jest-circus/runner',
+  moduleFileExtensions: ["js", "ts"],
+  testMatch: ["**/*.test.ts"],
   transform: {
-    '^.+\\.ts$': 'ts-jest'
+    "^.+\\.ts$": "ts-jest",
   },
-  verbose: true
-}
+  verbose: true,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@types/semver": "^7.5.0",
         "@vercel/ncc": "^0.36.1",
         "jest": "^29.6.1",
-        "jest-circus": "^29.6.0",
         "prettier": "^2.8.8",
         "ts-jest": "^29.1.1",
         "typescript": "^5.1.6"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@types/semver": "^7.5.0",
     "@vercel/ncc": "^0.36.1",
     "jest": "^29.6.1",
-    "jest-circus": "^29.6.0",
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.1",
     "typescript": "^5.1.6"


### PR DESCRIPTION
jest-circus is now the default test runner.

https://www.npmjs.com/package/jest-circus

> Note: As of Jest 27, jest-circus is the default test runner, so you do not have to install it to use it.