### PR TITLE
pre-install local::lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ The following Perl scripts are pre-installed for convenience.
 - [Net::SSLeay](https://metacpan.org/dist/Net-SSLeay/view/lib/Net/SSLeay.pod)
 - [IO::Socket::SSL](https://metacpan.org/dist/IO-Socket-SSL/view/lib/IO/Socket/SSL.pod)
 - [Mozilla::CA](https://metacpan.org/pod/Mozilla::CA)
+- [local::lib](https://metacpan.org/pod/local::lib)
 - [Win32](https://metacpan.org/pod/Win32) (installed from CPAN in perl 5.8.3 or earlier. From perl 5.8.4, it is installed as a core module.)
 
 ## Actions::Core

--- a/scripts/darwin/build.pl
+++ b/scripts/darwin/build.pl
@@ -182,6 +182,9 @@ sub run {
 
         # Test::Harness
         cpan_install('https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.48.tar.gz', 'Test-Harness', 'Test::Harness', '5.6.0', '5.8.3');
+
+        # local::lib
+        cpan_install('https://cpan.metacpan.org/authors/id/H/HA/HAARG/local-lib-2.000029.tar.gz', 'local-lib', 'local::lib', '5.6.0');
     };
 
     group "archiving" => sub {

--- a/scripts/linux/build.pl
+++ b/scripts/linux/build.pl
@@ -182,6 +182,9 @@ sub run {
 
         # Test::Harness
         cpan_install('https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.48.tar.gz', 'Test-Harness', 'Test::Harness', '5.6.0', '5.8.3');
+
+        # local::lib
+        cpan_install('https://cpan.metacpan.org/authors/id/H/HA/HAARG/local-lib-2.000029.tar.gz', 'local-lib', 'local::lib', '5.6.0');
     };
 
     group "archiving" => sub {

--- a/scripts/windows/build.pl
+++ b/scripts/windows/build.pl
@@ -252,6 +252,9 @@ sub run {
 
         # Test::Harness
         cpan_install('https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.48.tar.gz', 'Test-Harness', 'Test::Harness', '5.6.0', '5.8.3');
+
+        # local::lib
+        cpan_install('https://cpan.metacpan.org/authors/id/H/HA/HAARG/local-lib-2.000029.tar.gz', 'local-lib', 'local::lib', '5.6.0');
     };
 
     group "archiving" => sub {


### PR DESCRIPTION
By default, the action install CPAN modules into `local`.
Its directory layout is compatible with `local::lib`.