### PR TITLE
introduce M1 Mac

### DIFF
--- a/.github/build-openssl-darwin.sh
+++ b/.github/build-openssl-darwin.sh
@@ -16,7 +16,7 @@ fi
 case $(uname -m) in
   "x86_64")
     ARCH=x64;;
-  "aarch64")
+  "arm64")
     ARCH=arm64;;
   *)
     echo "unknown architecture: $(uname -m)"

--- a/.github/build-openssl-darwin.sh
+++ b/.github/build-openssl-darwin.sh
@@ -12,7 +12,16 @@ PERL_DIR=$PERL_VERSION
 if [[ "x$PERL_MULTI_THREAD" != "x" ]]; then
     PERL_DIR="$PERL_DIR-thr"
 fi
-PREFIX=$RUNNER_TOOL_CACHE/perl/$PERL_DIR/x64
+
+case $(uname -m) in
+  "x86_64")
+    ARCH=x64;;
+  "aarch64")
+    ARCH=arm64;;
+  *)
+    echo "unknown architecture: $(uname -m)"
+esac
+PREFIX=$RUNNER_TOOL_CACHE/perl/$PERL_DIR/$ARCH
 
 # detect the number of CPU Core
 JOBS=$(sysctl -n hw.logicalcpu_max)

--- a/.github/workflows/darwin-arm64.yml
+++ b/.github/workflows/darwin-arm64.yml
@@ -1,0 +1,167 @@
+name: build on darwin-arm64
+
+on:
+  pull_request:
+    paths:
+      - "versions/darwin.json"
+      - "scripts/darwin/**"
+      - "scripts/lib/Devel/**"
+      - ".github/workflows/darwin-arm64.yml"
+      - ".github/build-openssl-darwin.sh"
+  push:
+    branches:
+      - "releases/*"
+  schedule:
+    - cron: "10 15 * * 5"
+  workflow_dispatch:
+    inputs:
+      perl-versions:
+        description: perl versions to build (JSON Array)
+        required: false
+        default: ""
+
+jobs:
+  list:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-matrix
+        name: list available perl versions
+        run: |
+          if [ -n "$PERL_VERSIONS" ]; then
+            echo "matrix=$(printenv PERL_VERSIONS | jq -c '{perl: .}')" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=$(<versions/darwin.json jq -c '{perl: .}')" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PERL_VERSIONS: ${{ github.event.inputs.perl-versions }}
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+  sanity-check:
+    runs-on: macos-14
+    steps:
+      - id: perl
+        name: check pre-installed perl version
+        run: |
+          perl -e 'print "version=$^V\n"' >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: scripts/darwin/local
+          key: Darwin-sanity-check-perl-${{ steps.perl.outputs.version }}-${{ hashFiles('scripts/darwin/cpanfile.snapshot') }}
+          restore-keys: Darwin-sanity-check-perl-${{ steps.perl.outputs.version }}-
+      - name: sanity check
+        run: |
+          ../../bin/carton install --deployment
+          ../../bin/carton exec perl -c build.pl
+          ../../bin/carton exec perl -I../lib -c ../lib/Devel/PatchPerl/Plugin/GitHubActions.pm
+          ../../bin/carton exec perl -I../lib -c ../lib/Devel/PatchPerl/Plugin/MinGW.pm
+          ../../bin/carton exec perl -I../lib -c ../lib/Devel/PatchPerl/Plugin/MinGWGNUmakefile.pm
+        working-directory: ./scripts/darwin
+        env:
+          PERL5LIB: ${{ github.workspace }}/scripts/lib
+
+  build:
+    runs-on: macos-14
+    needs:
+      - sanity-check
+      - list
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.list.outputs.matrix)}}
+    env:
+      PERL_VERSION: ${{ matrix.perl }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: perl
+        name: setup host perl
+        run: |
+          perl -MConfig -E 'say "$Config{bin}"' >> "$GITHUB_PATH"
+          perl -e 'print "version=$^V\n"' >> "$GITHUB_OUTPUT"
+      - name: Host perl -V
+        run: perl -V
+      - name: gcc --version
+        run: gcc --version
+
+      - name: build OpenSSL
+        run: .github/build-openssl-darwin.sh
+
+      - uses: actions/cache@v4
+        with:
+          path: scripts/darwin/local
+          key: ${{ runner.os }}-${{ runner.arch }}-build-perl-${{ steps.perl.outputs.version }}-${{ hashFiles('scripts/darwin/cpanfile.snapshot') }}
+          restore-keys: ${{ runner.os }}-build-perl-${{ steps.perl.outputs.version }}-
+      - name: carton install --deployment
+        shell: bash
+        run: ../../bin/carton install --deployment
+        working-directory: ./scripts/darwin
+
+      - name: build
+        shell: bash
+        run: perl build.pl
+        env:
+          PERL5LIB: ${{ github.workspace }}/scripts/darwin/local/lib/perl5
+        working-directory: ./scripts/darwin
+
+      - name: upload
+        run: |
+          ACTIONS_VERSION=v$(<"$GITHUB_WORKSPACE/package.json" jq -r .version)
+          mv "$RUNNER_TEMP/perl.tar.zstd" "$RUNNER_TEMP/perl-$PERL_VERSION-darwin-arm64.tar.zstd"
+          gh release upload --clobber "$ACTIONS_VERSION" "$RUNNER_TEMP/perl-$PERL_VERSION-darwin-arm64.tar.zstd"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  build-multi-thread:
+    runs-on: macos-14
+    needs:
+      - sanity-check
+      - list
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.list.outputs.matrix)}}
+    env:
+      PERL_VERSION: ${{ matrix.perl }}
+      PERL_MULTI_THREAD: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - id: perl
+        name: setup host perl
+        run: |
+          perl -MConfig -E 'say "$Config{bin}"' >> "$GITHUB_PATH"
+          # shellcheck disable=SC2016
+          perl -e 'print "version=$^V\n"' >> "$GITHUB_OUTPUT"
+      - name: Host perl -V
+        run: perl -V
+      - name: gcc --version
+        run: gcc --version
+
+      - name: build OpenSSL
+        run: .github/build-openssl-darwin.sh
+
+      - uses: actions/cache@v4
+        with:
+          path: scripts/darwin/local
+          key: ${{ runner.os }}-${{ runner.arch }}-build-perl-${{ steps.perl.outputs.version }}-${{ hashFiles('scripts/darwin/cpanfile.snapshot') }}
+          restore-keys: ${{ runner.os }}-build-perl-${{ steps.perl.outputs.version }}-
+      - name: carton install --deployment
+        shell: bash
+        run: ../../bin/carton install --deployment
+        working-directory: ./scripts/darwin
+
+      - name: build
+        shell: bash
+        run: perl build.pl
+        env:
+          PERL5LIB: ${{ github.workspace }}/scripts/darwin/local/lib/perl5
+        working-directory: ./scripts/darwin
+
+      - name: upload
+        run: |
+          ACTIONS_VERSION=v$(<"$GITHUB_WORKSPACE/package.json" jq -r .version)
+          mv "$RUNNER_TEMP/perl.tar.zstd" "$RUNNER_TEMP/perl-$PERL_VERSION-darwin-arm64-multi-thread.tar.zstd"
+          gh release upload --clobber "$ACTIONS_VERSION" "$RUNNER_TEMP/perl-$PERL_VERSION-darwin-arm64-multi-thread.tar.zstd"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/darwin-x64.yml
+++ b/.github/workflows/darwin-x64.yml
@@ -1,4 +1,4 @@
-name: build on darwin
+name: build on darwin-x64
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - "versions/darwin.json"
       - "scripts/darwin/**"
       - "scripts/lib/Devel/**"
-      - ".github/workflows/darwin.yml"
+      - ".github/workflows/darwin-x64.yml"
       - ".github/build-openssl-darwin.sh"
   push:
     branches:
@@ -39,7 +39,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
   sanity-check:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - id: perl
         name: check pre-installed perl version
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: scripts/darwin/local
-          key: ${{ runner.os }}-build-perl-${{ steps.perl.outputs.version }}-${{ hashFiles('scripts/darwin/cpanfile.snapshot') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-build-perl-${{ steps.perl.outputs.version }}-${{ hashFiles('scripts/darwin/cpanfile.snapshot') }}
           restore-keys: ${{ runner.os }}-build-perl-${{ steps.perl.outputs.version }}-
       - name: carton install --deployment
         shell: bash
@@ -144,7 +144,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: scripts/darwin/local
-          key: ${{ runner.os }}-build-perl-${{ steps.perl.outputs.version }}-${{ hashFiles('scripts/darwin/cpanfile.snapshot') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-build-perl-${{ steps.perl.outputs.version }}-${{ hashFiles('scripts/darwin/cpanfile.snapshot') }}
           restore-keys: ${{ runner.os }}-build-perl-${{ steps.perl.outputs.version }}-
       - name: carton install --deployment
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - macos-14
           - macos-13
           - macos-12
           - macos-11

--- a/scripts/darwin/build.pl
+++ b/scripts/darwin/build.pl
@@ -27,8 +27,16 @@ if (my $cache = $ENV{RUNNER_TOOL_CACHE}) {
     }
     $runner_tool_cache = $cache;
 }
+chomp (my $arch = `uname -m`);
+if ($arch eq 'x86_64') {
+    $arch = 'x64';
+} elsif ($arch eq 'aarch64') {
+    $arch = 'arm64';
+} else {
+    die "unsupported arch: $arch";
+}
 my $install_dir = File::Spec->rel2abs(
-    File::Spec->catdir($runner_tool_cache, "perl", $version . ($thread ? "-thr" : ""), "x64"));
+    File::Spec->catdir($runner_tool_cache, "perl", $version . ($thread ? "-thr" : ""), $arch));
 my $perl = File::Spec->catfile($install_dir, 'bin', 'perl');
 
 # read cpanfile snapshot

--- a/scripts/darwin/build.pl
+++ b/scripts/darwin/build.pl
@@ -30,7 +30,7 @@ if (my $cache = $ENV{RUNNER_TOOL_CACHE}) {
 chomp (my $arch = `uname -m`);
 if ($arch eq 'x86_64') {
     $arch = 'x64';
-} elsif ($arch eq 'aarch64') {
+} elsif ($arch eq 'arm64') {
     $arch = 'arm64';
 } else {
     die "unsupported arch: $arch";


### PR DESCRIPTION
- GitHub Actions: Introducing the new M1 macOS runner available to open source!: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
- GitHub Actions: macOS 14 (Sonoma) is now available: https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Expanded testing to include macOS 14 in the test matrix.
	- Introduced GitHub Actions workflow for building and uploading Perl binaries on the darwin-arm64 platform.
	- Updated workflow for building on darwin-x64 to specify the correct architecture and key for caching.
	- Modified the `build.pl` script to dynamically determine the architecture and construct the install directory path accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->