### PR TITLE
disable useshrplib on perl 5.8.8 or earlier on macOS

### DIFF
--- a/scripts/darwin/build.pl
+++ b/scripts/darwin/build.pl
@@ -124,9 +124,12 @@ sub run {
             "-de",
             # omit man
             "-Dman1dir=none", "-Dman3dir=none",
-            # enable shared library and PIC, fixes https://github.com/shogo82148/actions-setup-perl/issues/1756
-            "-Dcccdlflags=-fPIC", "-Duseshrplib",
         );
+        # enable shared library and PIC, fixes https://github.com/shogo82148/actions-setup-perl/issues/1756
+        # on perl 5.8.8 or earlier, useshrplib doesn't work.
+        if (version->parse("v$version") >= version->parse("v5.8.9")) {
+            push @options, "-Dcccdlflags=-fPIC", "-Duseshrplib";
+        }
         if ($thread) {
             # enable multi threading
             push @options, "-Duseithreads";


### PR DESCRIPTION
on perl 5.8.8 or earlier, useshrplib doesn't work.
the log of builds:

```
cc -mmacosx-version-min=14.2 -L/usr/local/lib -force_flat_namespace -o miniperl \
	    miniperlmain.o opmini.o libperl.dylib
ld: warning: -force_flat_namespace is no longer supported, using -flat_namespace instead
DYLD_LIBRARY_PATH=/private/var/folders/tm/cs38gmb51tl2c8r0pg05g5_40000gn/T/gmUVA0IEu3/perl-5.8.8 ./miniperl -w -Ilib -MExporter -e '<?>' || /Library/Developer/CommandLineTools/usr/bin/make minitest
Can't locate File/Glob.pm in @INC (@INC contains: lib /Users/shogo/src/github.com/shogo82148/actions-setup-perl/scripts/darwin/tmp/perl/5.8.8/arm64/lib/5.8.8/darwin-2level /Users/shogo/src/github.com/shogo82148/actions-setup-perl/scripts/darwin/tmp/perl/5.8.8/arm64/lib/5.8.8 /Users/shogo/src/github.com/shogo82148/actions-setup-perl/scripts/darwin/tmp/perl/5.8.8/arm64/lib/site_perl/5.8.8/darwin-2level /Users/shogo/src/github.com/shogo82148/actions-setup-perl/scripts/darwin/tmp/perl/5.8.8/arm64/lib/site_perl/5.8.8 /Users/shogo/src/github.com/shogo82148/actions-setup-perl/scripts/darwin/tmp/perl/5.8.8/arm64/lib/site_perl .) at -e line 1.
BEGIN failed--compilation aborted at -e line 1.
cp ext/re/re.pm lib/re.pm
DYLD_LIBRARY_PATH=/private/var/folders/tm/cs38gmb51tl2c8r0pg05g5_40000gn/T/gmUVA0IEu3/perl-5.8.8 ./miniperl -Ilib configpm --heavy=lib/Config_heavy.pl lib/Config.pm
DYLD_LIBRARY_PATH=/private/var/folders/tm/cs38gmb51tl2c8r0pg05g5_40000gn/T/gmUVA0IEu3/perl-5.8.8 ./miniperl -Ilib lib/lib_pm.PL
Extracting lib.pm (with variable substitutions)
cd lib/unicore && DYLD_LIBRARY_PATH=/private/var/folders/tm/cs38gmb51tl2c8r0pg05g5_40000gn/T/gmUVA0IEu3/perl-5.8.8 ../../miniperl -I../../lib mktables -w
Can't locate File/Glob.pm in @INC (@INC contains: ../../lib /Users/shogo/src/github.com/shogo82148/actions-setup-perl/scripts/darwin/tmp/perl/5.8.8/arm64/lib/5.8.8/darwin-2level /Users/shogo/src/github.com/shogo82148/actions-setup-perl/scripts/darwin/tmp/perl/5.8.8/arm64/lib/5.8.8 /Users/shogo/src/github.com/shogo82148/actions-setup-perl/scripts/darwin/tmp/perl/5.8.8/arm64/lib/site_perl/5.8.8/darwin-2level /Users/shogo/src/github.com/shogo82148/actions-setup-perl/scripts/darwin/tmp/perl/5.8.8/arm64/lib/site_perl/5.8.8 /Users/shogo/src/github.com/shogo82148/actions-setup-perl/scripts/darwin/tmp/perl/5.8.8/arm64/lib/site_perl .) at mktables line 2111.
BEGIN failed--compilation aborted at mktables line 2111.
make[2]: *** [uni.data] Error 2
make[1]: [minitest.prep] Error 2 (ignored)

You may see some irrelevant test failures if you have been unable
to build lib/Config.pm, lib/lib.pm or the Unicode data files.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved build options for shared library and Position Independent Code (PIC) to ensure compatibility with Perl versions 5.8.8 and earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->