### PR TITLE
drop support of macos-11

### DIFF
--- a/.github/build-openssl-darwin.sh
+++ b/.github/build-openssl-darwin.sh
@@ -58,5 +58,4 @@ echo "::endgroup::"
 # configure for building Net::SSLeay
 cat <<__END__  >> "$GITHUB_ENV"
 OPENSSL_PREFIX=$PREFIX
-DYLD_LIBRARY_PATH=$PREFIX/lib:$DYLD_LIBRARY_PATH
 __END__

--- a/.github/build-openssl-linux.sh
+++ b/.github/build-openssl-linux.sh
@@ -49,8 +49,4 @@ echo "::endgroup::"
 # configure for building Net::SSLeay
 cat <<__END__  >> "$GITHUB_ENV"
 OPENSSL_PREFIX=$PREFIX
-LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH
 __END__
-
-export LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH
-sudo ldconfig

--- a/.github/workflows/darwin-x64.yml
+++ b/.github/workflows/darwin-x64.yml
@@ -39,7 +39,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
   sanity-check:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - id: perl
         name: check pre-installed perl version
@@ -63,7 +63,7 @@ jobs:
           PERL5LIB: ${{ github.workspace }}/scripts/lib
 
   build:
-    runs-on: macos-11
+    runs-on: macos-12
     needs:
       - sanity-check
       - list
@@ -114,7 +114,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   build-multi-thread:
-    runs-on: macos-11
+    runs-on: macos-12
     needs:
       - sanity-check
       - list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,6 @@ jobs:
           - macos-14
           - macos-13
           - macos-12
-          - macos-11
         multi-thread:
           - false
           - true

--- a/.github/workflows/update-build-tools.yml
+++ b/.github/workflows/update-build-tools.yml
@@ -31,7 +31,7 @@ jobs:
           path: scripts/linux/cpanfile.snapshot
 
   darwin:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: setup host perl
         run: perl -MConfig -E 'say "$Config{bin}"' >> "$GITHUB_PATH"

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ The action works for [GitHub-hosted runners](https://docs.github.com/en/actions/
 
 | Operating System | Supported Versions                             |
 | ---------------- | ---------------------------------------------- |
-| Linux            | `ubuntu-20.04`, `ubuntu-22.04`                 |
-| macOS            | `macos-11`, `macos-12`, `macos-13`, `macos-14` |
+| Linux            | `ubuntu-20.04`, `ubuntu-22.04`, `ubuntu-24.04` |
+| macOS            | `macos-12`, `macos-13`, `macos-14`             |
 | Windows          | `windows-2019`, `windows-2022`                 |
 
 [Self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners) are not supported.


### PR DESCRIPTION
> The macOS 11 runner image will be removed on 6/28/2024.

- https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
- https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to use `macos-12` instead of `macos-11`.
  - Removed `macos-11` from the supported macOS versions in workflows.
  - Updated supported Linux version in README from `ubuntu-22.04` to `ubuntu-24.04`.
  - Removed environment variable settings for `DYLD_LIBRARY_PATH` and `LD_LIBRARY_PATH` in build scripts.

These changes ensure compatibility with newer operating system versions and streamline the build and test processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->