### PR TITLE
drop macos-12 support

### DIFF
--- a/.github/workflows/darwin-x64.yml
+++ b/.github/workflows/darwin-x64.yml
@@ -39,7 +39,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
   sanity-check:
-    runs-on: macos-12
+    runs-on: macos-13
     permissions:
       contents: read
     steps:
@@ -65,7 +65,7 @@ jobs:
           PERL5LIB: ${{ github.workspace }}/scripts/lib
 
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     needs:
       - sanity-check
       - list
@@ -124,7 +124,7 @@ jobs:
           subject-path: ${{ runner.temp }}/*.tar.zstd
 
   build-multi-thread:
-    runs-on: macos-12
+    runs-on: macos-13
     needs:
       - sanity-check
       - list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,6 @@ jobs:
           - macos-15
           - macos-14
           - macos-13
-          - macos-12
         multi-thread:
           - false
           - true

--- a/.github/workflows/update-build-tools.yml
+++ b/.github/workflows/update-build-tools.yml
@@ -31,7 +31,7 @@ jobs:
           path: scripts/linux/cpanfile.snapshot
 
   darwin:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: setup host perl
         run: perl -MConfig -E 'say "$Config{bin}"' >> "$GITHUB_PATH"

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The action works for [GitHub-hosted runners](https://docs.github.com/en/actions/
 | Operating System | Supported Versions                             |
 | ---------------- | ---------------------------------------------- |
 | Linux            | `ubuntu-20.04`, `ubuntu-22.04`, `ubuntu-24.04` |
-| macOS            | `macos-12`, `macos-13`, `macos-14`             |
+| macOS            | `macos-13`, `macos-14`, `macos-15`             |
 | Windows          | `windows-2019`, `windows-2022`                 |
 
 [Self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners) are not supported.

--- a/scripts/common/cpanfile.snapshot
+++ b/scripts/common/cpanfile.snapshot
@@ -6,10 +6,10 @@ DISTRIBUTIONS
       Canary::Stability 2013
     requirements:
       ExtUtils::MakeMaker 0
-  Cpanel-JSON-XS-4.38
-    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.38.tar.gz
+  Cpanel-JSON-XS-4.39
+    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.39.tar.gz
     provides:
-      Cpanel::JSON::XS 4.38
+      Cpanel::JSON::XS 4.39
       Cpanel::JSON::XS::Type undef
     requirements:
       Carp 0
@@ -53,7 +53,7 @@ DISTRIBUTIONS
       JSON::MaybeXS 1.004008
     requirements:
       Carp 0
-      Cpanel::JSON::XS 2.3310
+      Cpanel::JSON::XS 4.38
       ExtUtils::MakeMaker 0
       JSON::PP 2.27300
       Scalar::Util 0
@@ -146,10 +146,10 @@ DISTRIBUTIONS
       perl 5.008001
       strict 0
       warnings 0
-  YAML-Tiny-1.74
-    pathname: E/ET/ETHER/YAML-Tiny-1.74.tar.gz
+  YAML-Tiny-1.76
+    pathname: E/ET/ETHER/YAML-Tiny-1.76.tar.gz
     provides:
-      YAML::Tiny 1.74
+      YAML::Tiny 1.76
     requirements:
       B 0
       Carp 0


### PR DESCRIPTION
The macOS 12 runner image has been deprecated on 10/7/2024, and will be fully unsupported by 12/3/2024

- https://github.com/actions/runner-images/issues/10721
- https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new jobs for testing on Windows and Ubuntu environments.
	- Expanded compatibility to support macOS versions 13, 14, and 15.

- **Bug Fixes**
	- Updated workflows to remove deprecated macOS version and address known issues with Perl in Python on macOS 13.

- **Documentation**
	- Updated the README to reflect changes in supported platforms and clarified usage examples.

- **Chores**
	- Updated Perl distribution versions in the cpanfile snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->