### PR TITLE
add windows-2025 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,6 +184,7 @@ jobs:
         os:
           - windows-2019
           - windows-2022
+          - windows-2025
         multi-thread:
           - false
           - true
@@ -267,6 +268,8 @@ jobs:
       matrix:
         os:
           - windows-2019
+          - windows-2022
+          - windows-2025
     steps:
       - name: disable autocrlf
         run: git config --global core.autocrlf false


### PR DESCRIPTION
https://github.blog/changelog/2024-12-19-windows-server-2025-is-now-in-public-preview/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded testing environment with additional operating system support for Windows and Strawberry distributions.
- **Bug Fixes**
	- Commented out a problematic test step in the Darwin job to address a known issue on macOS.
- **Chores**
	- Overall workflow structure remains intact with no changes to existing job logic or commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->