### PR TITLE
add ARM64 support for Ubuntu

### DIFF
--- a/.github/build-openssl-darwin.sh
+++ b/.github/build-openssl-darwin.sh
@@ -16,7 +16,7 @@ fi
 case $(uname -m) in
   "x86_64")
     ARCH=x64;;
-  "arm64")
+  "arm64" | "aarch64")
     ARCH=arm64;;
   *)
     echo "unknown architecture: $(uname -m)"

--- a/.github/build-openssl-linux.sh
+++ b/.github/build-openssl-linux.sh
@@ -12,7 +12,15 @@ PERL_DIR=$PERL_VERSION
 if [[ "x$PERL_MULTI_THREAD" != "x" ]]; then
     PERL_DIR="$PERL_DIR-thr"
 fi
-PREFIX=$RUNNER_TOOL_CACHE/perl/$PERL_DIR/x64
+case $(uname -m) in
+  "x86_64")
+    ARCH=x64;;
+  "arm64" | "aarch64")
+    ARCH=arm64;;
+  *)
+    echo "unknown architecture: $(uname -m)"
+esac
+PREFIX=$RUNNER_TOOL_CACHE/perl/$PERL_DIR/$ARCH
 
 # detect the number of CPU Core
 JOBS=$(nproc)

--- a/.github/build-openssl-linux.sh
+++ b/.github/build-openssl-linux.sh
@@ -18,7 +18,8 @@ case $(uname -m) in
   "arm64" | "aarch64")
     ARCH=arm64;;
   *)
-    echo "unknown architecture: $(uname -m)"
+    echo "unknown architecture: $(uname -m)" >&2
+    exit 1
 esac
 PREFIX=$RUNNER_TOOL_CACHE/perl/$PERL_DIR/$ARCH
 

--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -1,4 +1,4 @@
-name: build on linux
+name: build on linux-arm64
 
 on:
   pull_request:

--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -114,8 +114,8 @@ jobs:
       - name: upload
         run: |
           ACTIONS_VERSION=v$(<"$GITHUB_WORKSPACE/package.json" jq -r .version)
-          mv "$RUNNER_TEMP/perl.tar.zstd" "$RUNNER_TEMP/perl-$PERL_VERSION-linux-x64.tar.zstd"
-          gh release upload --clobber "$ACTIONS_VERSION" "$RUNNER_TEMP/perl-$PERL_VERSION-linux-x64.tar.zstd"
+          mv "$RUNNER_TEMP/perl.tar.zstd" "$RUNNER_TEMP/perl-$PERL_VERSION-linux-arm64.tar.zstd"
+          gh release upload --clobber "$ACTIONS_VERSION" "$RUNNER_TEMP/perl-$PERL_VERSION-linux-arm64.tar.zstd"
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -174,8 +174,8 @@ jobs:
       - name: upload
         run: |
           ACTIONS_VERSION=v$(<"$GITHUB_WORKSPACE/package.json" jq -r .version)
-          mv "$RUNNER_TEMP/perl.tar.zstd" "$RUNNER_TEMP/perl-$PERL_VERSION-linux-x64-multi-thread.tar.zstd"
-          gh release upload --clobber "$ACTIONS_VERSION" "$RUNNER_TEMP/perl-$PERL_VERSION-linux-x64-multi-thread.tar.zstd"
+          mv "$RUNNER_TEMP/perl.tar.zstd" "$RUNNER_TEMP/perl-$PERL_VERSION-linux-arm64-multi-thread.tar.zstd"
+          gh release upload --clobber "$ACTIONS_VERSION" "$RUNNER_TEMP/perl-$PERL_VERSION-linux-arm64-multi-thread.tar.zstd"
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -1,0 +1,184 @@
+name: build on linux
+
+on:
+  pull_request:
+    paths:
+      - "versions/linux.json"
+      - "scripts/linux/**"
+      - "scripts/lib/Devel/**"
+      - ".github/workflows/linux-arm64.yml"
+      - ".github/build-openssl-linux.sh"
+  push:
+    branches:
+      - "releases/*"
+  workflow_dispatch:
+    inputs:
+      perl-versions:
+        description: perl versions to build (JSON Array)
+        required: false
+        default: ""
+
+jobs:
+  list:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-matrix
+        name: list available perl versions
+        run: |
+          if [ -n "$PERL_VERSIONS" ]; then
+            echo "matrix=$(printenv PERL_VERSIONS | jq -c '{perl: .}')" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=$(<versions/linux.json jq -c '{perl: .}')" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PERL_VERSIONS: ${{ github.event.inputs.perl-versions }}
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+  sanity-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - id: perl
+        name: check pre-installed perl version
+        run: |
+          perl -e 'print "version=$^V\n"' >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: scripts/linux/local
+          key: Linux-sanity-check-perl-${{ steps.perl.outputs.version }}-${{ hashFiles('scripts/linux/cpanfile.snapshot') }}
+          restore-keys: Linux-sanity-check-perl-${{ steps.perl.outputs.version }}-
+      - name: sanity check
+        run: |
+          ../../bin/carton install --deployment
+          ../../bin/carton exec perl -c build.pl
+          ../../bin/carton exec perl -I../lib -c ../lib/Devel/PatchPerl/Plugin/GitHubActions.pm
+          ../../bin/carton exec perl -I../lib -c ../lib/Devel/PatchPerl/Plugin/MinGW.pm
+          ../../bin/carton exec perl -I../lib -c ../lib/Devel/PatchPerl/Plugin/MinGWGNUmakefile.pm
+        working-directory: ./scripts/linux
+        env:
+          PERL5LIB: ${{ github.workspace }}/scripts/lib
+
+  build:
+    runs-on: ubuntu-22.04-arm
+    needs:
+      - list
+      - sanity-check
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.list.outputs.matrix)}}
+    env:
+      PERL_VERSION: ${{ matrix.perl }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: perl
+        name: setup host perl
+        run: |
+          perl -MConfig -E 'say "$Config{bin}"' >> "$GITHUB_PATH"
+          perl -e 'print "version=$^V\n"' >> "$GITHUB_OUTPUT"
+      - name: Host perl -V
+        run: perl -V
+      - name: gcc --version
+        run: gcc --version
+
+      - name: build OpenSSL
+        run: .github/build-openssl-linux.sh
+
+      - uses: actions/cache@v4
+        with:
+          path: scripts/linux/local
+          key: ${{ runner.os }}-build-perl-${{ steps.perl.outputs.version }}-${{ hashFiles('scripts/linux/cpanfile.snapshot') }}
+          restore-keys: ${{ runner.os }}-build-perl-${{ steps.perl.outputs.version }}-
+      - name: carton install --deployment
+        shell: bash
+        run: ../../bin/carton install --deployment
+        working-directory: ./scripts/linux
+
+      - name: build
+        shell: bash
+        run: perl build.pl
+        env:
+          PERL5LIB: ${{ github.workspace }}/scripts/linux/local/lib/perl5
+        working-directory: ./scripts/linux
+
+      - name: upload
+        run: |
+          ACTIONS_VERSION=v$(<"$GITHUB_WORKSPACE/package.json" jq -r .version)
+          mv "$RUNNER_TEMP/perl.tar.zstd" "$RUNNER_TEMP/perl-$PERL_VERSION-linux-x64.tar.zstd"
+          gh release upload --clobber "$ACTIONS_VERSION" "$RUNNER_TEMP/perl-$PERL_VERSION-linux-x64.tar.zstd"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ runner.temp }}/*.tar.zstd
+
+  build-multi-thread:
+    runs-on: ubuntu-22.04-arm
+    needs:
+      - sanity-check
+      - list
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.list.outputs.matrix)}}
+    env:
+      PERL_VERSION: ${{ matrix.perl }}
+      PERL_MULTI_THREAD: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - id: perl
+        name: setup host perl
+        run: |
+          perl -MConfig -E 'say "$Config{bin}"' >> "$GITHUB_PATH"
+          perl -e 'print "version=$^V\n"' >> "$GITHUB_OUTPUT"
+      - name: Host perl -V
+        run: perl -V
+      - name: gcc --version
+        run: gcc --version
+
+      - name: build OpenSSL
+        run: .github/build-openssl-linux.sh
+
+      - uses: actions/cache@v4
+        with:
+          path: scripts/linux/local
+          key: ${{ runner.os }}-build-perl-${{ steps.perl.outputs.version }}-${{ hashFiles('scripts/linux/cpanfile.snapshot') }}
+          restore-keys: ${{ runner.os }}-build-perl-${{ steps.perl.outputs.version }}-
+      - name: carton install --deployment
+        shell: bash
+        run: ../../bin/carton install --deployment
+        working-directory: ./scripts/linux
+
+      - name: build
+        shell: bash
+        run: perl build.pl
+        env:
+          PERL5LIB: ${{ github.workspace }}/scripts/linux/local/lib/perl5
+        working-directory: ./scripts/linux
+
+      - name: upload
+        run: |
+          ACTIONS_VERSION=v$(<"$GITHUB_WORKSPACE/package.json" jq -r .version)
+          mv "$RUNNER_TEMP/perl.tar.zstd" "$RUNNER_TEMP/perl-$PERL_VERSION-linux-x64-multi-thread.tar.zstd"
+          gh release upload --clobber "$ACTIONS_VERSION" "$RUNNER_TEMP/perl-$PERL_VERSION-linux-x64-multi-thread.tar.zstd"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ runner.temp }}/*.tar.zstd

--- a/.github/workflows/linux-x64.yml
+++ b/.github/workflows/linux-x64.yml
@@ -6,7 +6,7 @@ on:
       - "versions/linux.json"
       - "scripts/linux/**"
       - "scripts/lib/Devel/**"
-      - ".github/workflows/linux.yml"
+      - ".github/workflows/linux-x64.yml"
       - ".github/build-openssl-linux.sh"
   push:
     branches:

--- a/.github/workflows/linux-x64.yml
+++ b/.github/workflows/linux-x64.yml
@@ -1,4 +1,4 @@
-name: build on linux
+name: build on linux-x64
 
 on:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
           - ubuntu-24.04
           - ubuntu-22.04
           - ubuntu-20.04
+          - ubuntu-24.04-arm64
+          - ubuntu-22.04-arm64
         multi-thread:
           - false
           - true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
           - ubuntu-24.04
           - ubuntu-22.04
           - ubuntu-20.04
-          - ubuntu-24.04-arm64
-          - ubuntu-22.04-arm64
+          - ubuntu-24.04-arm
+          - ubuntu-22.04-arm
         multi-thread:
           - false
           - true

--- a/scripts/darwin/build.pl
+++ b/scripts/darwin/build.pl
@@ -30,7 +30,7 @@ if (my $cache = $ENV{RUNNER_TOOL_CACHE}) {
 chomp (my $arch = `uname -m`);
 if ($arch eq 'x86_64') {
     $arch = 'x64';
-} elsif ($arch eq 'arm64') {
+} elsif ($arch eq 'arm64' || $arch eq 'aarch64') {
     $arch = 'arm64';
 } else {
     die "unsupported arch: $arch";

--- a/scripts/linux/build.pl
+++ b/scripts/linux/build.pl
@@ -26,8 +26,16 @@ if (my $cache = $ENV{RUNNER_TOOL_CACHE}) {
     }
     $runner_tool_cache = $cache;
 }
+chomp (my $arch = `uname -m`);
+if ($arch eq 'x86_64') {
+    $arch = 'x64';
+} elsif ($arch eq 'arm64' || $arch eq 'aarch64') {
+    $arch = 'arm64';
+} else {
+    die "unsupported arch: $arch";
+}
 my $install_dir = File::Spec->rel2abs(
-    File::Spec->catdir($runner_tool_cache, "perl", $version . ($thread ? "-thr" : ""), "x64"));
+    File::Spec->catdir($runner_tool_cache, "perl", $version . ($thread ? "-thr" : ""), $arch));
 my $perl = File::Spec->catfile($install_dir, 'bin', 'perl');
 
 # read cpanfile snapshot


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced GitHub Actions workflow to support testing on additional Ubuntu ARM64 architectures (24.04 and 22.04).
	- Expanded testing compatibility across different hardware platforms.
	- Introduced a new workflow for building Perl on Linux ARM64 architecture with multiple jobs for version listing, sanity checks, and builds.
	- Updated workflow name and paths to ensure correct trigger conditions for CI/CD processes.
	- Improved architecture detection logic in build scripts to accommodate both ARM64 and AArch64.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->