### PR TITLE
drop support of Ubuntu 20.04

### DIFF
--- a/.github/workflows/linux-x64.yml
+++ b/.github/workflows/linux-x64.yml
@@ -65,7 +65,7 @@ jobs:
           PERL5LIB: ${{ github.workspace }}/scripts/lib
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - list
       - sanity-check
@@ -124,7 +124,7 @@ jobs:
           subject-path: ${{ runner.temp }}/*.tar.zstd
 
   build-multi-thread:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - sanity-check
       - list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
         os:
           - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
           - ubuntu-24.04-arm
           - ubuntu-22.04-arm
         multi-thread:

--- a/.github/workflows/update-build-tools.yml
+++ b/.github/workflows/update-build-tools.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ This option is available on Windows and falls back to the default customized bin
 
 The action works for [GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners).
 
-| Operating System | Supported Versions                             |
-| ---------------- | ---------------------------------------------- |
-| Linux            | `ubuntu-20.04`, `ubuntu-22.04`, `ubuntu-24.04` |
-| macOS            | `macos-13`, `macos-14`, `macos-15`             |
-| Windows          | `windows-2019`, `windows-2022`                 |
+| Operating System | Supported Versions                 |
+| ---------------- | ---------------------------------- |
+| Linux            | `ubuntu-22.04`, `ubuntu-24.04`     |
+| macOS            | `macos-13`, `macos-14`, `macos-15` |
+| Windows          | `windows-2019`, `windows-2022`     |
 
 [Self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners) are not supported.
 


### PR DESCRIPTION
ref. https://github.com/actions/runner-images/issues/11101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build, testing, and toolchain environments to run on newer Linux releases (Ubuntu 22.04/24.04) for improved consistency.
  - Streamlined testing by removing older, unsupported Linux versions.
  
- **Documentation**
  - Revised the supported operating systems table to reflect current Linux version standards for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->