### PR TITLE
chore: update Perl version from 5.40 to 5.42 in CI configuration

### DIFF
--- a/.github/workflows/test-cpan-installer.yml
+++ b/.github/workflows/test-cpan-installer.yml
@@ -31,20 +31,20 @@ jobs:
           - cpm
           - carton
         perl:
-          - "5.40" # latest version of Perl 5
+          - "5.42" # latest version of Perl 5
           - "5.8"
         distribution:
           - "default"
         include:
-          - perl: "5.40"
+          - perl: "5.42" # latest version of Perl 5
             os: "windows-latest"
             installer: "cpanm"
             distribution: "strawberry"
-          - perl: "5.40"
+          - perl: "5.42" # latest version of Perl 5
             os: "windows-latest"
             installer: "cpm"
             distribution: "strawberry"
-          - perl: "5.40"
+          - perl: "5.42" # latest version of Perl 5
             os: "windows-latest"
             installer: "carton"
             distribution: "strawberry"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI testing infrastructure to use Perl 5.42 across Windows and default test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->