### PR TITLE
chore: Add new Strawberry Perl versions and their SHA256 checksums

### DIFF
--- a/versions/strawberry.json
+++ b/versions/strawberry.json
@@ -5,9 +5,24 @@
         "sha256": "a1cde185656cf307b51670eed69f648b9eff15b5c518cb136e027c628e650b71"
     },
     {
+        "version": "5.40.2",
+        "release": "2",
+        "sha256": "7df5cdc41e8638c00b2aa00cccc69ec8cd5a5ad0ec265c81f389beffb53b6920"
+    },
+    {
+        "version": "5.40.2",
+        "release": "1",
+        "sha256": "7707700d5ad027773b775134fe48cd9610abf221433fcfb68c8eb0ec9c6fde8c"
+    },
+    {
         "version": "5.40.0",
         "release": "1",
         "sha256": "754f3e2a8e473dc68d1540c7802fb166a025f35ef18960c4564a31f8b5933907"
+    },
+    {
+        "version": "5.38.4",
+        "release": "1",
+        "sha256": "207e359c94c1431e618a4fb0ea54d810ef70b040abd71b9e31862146932b14b7"
     },
     {
         "version": "5.38.2",
@@ -28,6 +43,11 @@
         "version": "5.36.1",
         "release": "1",
         "sha256": "96dc0fc440e3123dd8d58df3498e41caba20610f33ed67af937a61b296c4786c"
+    },
+    {
+        "version": "5.34.3",
+        "release": "1",
+        "sha256": "94d312ed536bb5bec8d4d8a069c19cf5f275364b94bb4dd93da1c1aa5ef7652a"
     },
     {
         "version": "5.32.1",


### PR DESCRIPTION
closes https://github.com/shogo82148/actions-setup-perl/issues/2349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added version records for multiple recent releases, including versions 5.40.2, 5.38.4, and 5.34.3 with their corresponding checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->