### PR TITLE
drop macos-13 support

### DIFF
--- a/.github/workflows/darwin-x64.yml
+++ b/.github/workflows/darwin-x64.yml
@@ -39,7 +39,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
   sanity-check:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     permissions:
       contents: read
     steps:
@@ -65,7 +65,7 @@ jobs:
           PERL5LIB: ${{ github.workspace }}/scripts/lib
 
   build:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs:
       - sanity-check
       - list
@@ -124,7 +124,7 @@ jobs:
           subject-path: ${{ runner.temp }}/*.tar.zstd
 
   build-multi-thread:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs:
       - sanity-check
       - list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,9 +106,9 @@ jobs:
       matrix:
         os:
           - macos-26
+          - macos-15-intel
           - macos-15
           - macos-14
-          - macos-13
         multi-thread:
           - false
           - true
@@ -147,12 +147,11 @@ jobs:
       - name: run perl -V on pwsh
         run: perl -V
         shell: pwsh
-      # skip this test because it fails on macos-13: https://github.com/actions/runner-images/issues/7488
-      # - name: run perl -V on python
-      #   run: |
-      #     import subprocess
-      #     subprocess.call(['perl', '-V'])
-      #   shell: python
+      - name: run perl -V on python
+        run: |
+          import subprocess
+          subprocess.call(['perl', '-V'])
+        shell: python
       - name: run perl -V on sh
         run: perl -V
         shell: sh

--- a/.github/workflows/update-build-tools.yml
+++ b/.github/workflows/update-build-tools.yml
@@ -31,7 +31,7 @@ jobs:
           path: scripts/linux/cpanfile.snapshot
 
   darwin:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: setup host perl
         run: perl -MConfig -E 'say "$Config{bin}"' >> "$GITHUB_PATH"

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ This option is available on Windows and falls back to the default customized bin
 
 The action works for [GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners).
 
-| Operating System | Supported Versions                 |
-| ---------------- | ---------------------------------- |
-| Linux            | `ubuntu-22.04`, `ubuntu-24.04`     |
-| macOS            | `macos-13`, `macos-14`, `macos-15` |
-| Windows          | `windows-2022`, `windows-2025`     |
+| Operating System | Supported Versions                                   |
+| ---------------- | ---------------------------------------------------- |
+| Linux            | `ubuntu-22.04`, `ubuntu-24.04`                       |
+| macOS            | `macos-14`, `macos-15`, `macos-15-intel`, `macos-26` |
+| Windows          | `windows-2022`, `windows-2025`                       |
 
 [Self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners) are not supported.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build and test infrastructure to use newer runner configurations.
  * Activated additional testing procedures for macOS environments.

* **Documentation**
  * Expanded OS support documentation to include additional macOS versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->