### PR TITLE
Update readme about cpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Enables interpreter-based threads (ithread) options (`-Duseithreads`). `true` an
 ### `install-modules-with`
 
 Install CPAN modules from your `cpanfile` with the specified installer.
-`cpanm`([App::cpanminus](https://metacpan.org/pod/App::cpanminus)), `cpm`([App::cpm](https://metacpan.org/pod/App::cpm)), and `carton`([Carton](https://metacpan.org/pod/Carton)) are available.
+`cpanm`([App::cpanminus](https://metacpan.org/pod/App::cpanminus)), `cpm`([App::cpm](https://metacpan.org/pod/App::cpm), required Perl 5.24 or later.), and `carton`([Carton](https://metacpan.org/pod/Carton)) are available.
 CPAN modules is installed into `${working-directory}/local/`.
 
 - Default: Nothing. Any CPAN module is not installed.
@@ -195,7 +195,7 @@ The following Perl scripts are pre-installed for convenience.
 
 - [carton](https://metacpan.org/pod/distribution/Carton/script/carton)
 - [cpanm](https://metacpan.org/pod/distribution/App-cpanminus/bin/cpanm)
-- [cpm](https://metacpan.org/pod/distribution/App-cpm/script/cpm)
+- [cpm](https://metacpan.org/pod/distribution/App-cpm/script/cpm) (required Perl 5.24 or later.)
 
 # Pre-installed Modules
 

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
   install-modules-with:
     description: |
       install CPAN modules from your cpanfile with the specified installer.
-      cpanm(App::cpanminus), cpm(App::cpm), and carton(Carton) are available.
+      cpanm(App::cpanminus), cpm(App::cpm, required Perl 5.24 or later.), and carton(Carton) are available.
       By default, any CPAN modules are not installed.
     required: false
   install-modules-args:

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "Setup Perl environment"
 description: "Setup a Perl environment and add it to the PATH"
-author: "Ichinose Shogo"
+author: "ICHINOSE Shogo"
 inputs:
   github-token:
     description: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `cpm` requires Perl 5.24 or later in installation instructions and action metadata.

* **Chores**
  * Updated action metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->