### PR TITLE
Require CPAN::Meta in author/carton to keep it fat-packed

### DIFF
--- a/author/carton/cpanfile
+++ b/author/carton/cpanfile
@@ -3,6 +3,14 @@ requires 'perl', '5.006';
 requires 'Carton';
 requires 'Menlo::Legacy';
 requires 'Menlo';
+# CPAN::Meta is only a transitive dependency of Carton, and the base perl already
+# bundles a copy in its core lib, so `carton install` (make update) considers it
+# satisfied and never installs it into local/. App::FatPacker::Simple fatpacks only
+# what is under local/, so the generated carton would be missing CPAN::Meta.
+# Requiring it here (pinned above the base perl's bundled version) forces it into
+# local/ so it gets fat-packed. 2.150015+ needs CPAN::Meta::Requirements 2.145,
+# which doesn't support perl 5.8, so keep it at 2.150013.
+requires 'CPAN::Meta', '==2.150013';
 requires 'CPAN::Meta::Requirements', '==2.140'; # 2.141 doesn't support perl 5.8.
 requires 'Distribution::Metadata', '==0.06';
 requires 'App::FatPacker::Simple', '==0.09';


### PR DESCRIPTION
## Problem

The fat-packed `carton` generated from `author/carton` was missing `CPAN::Meta`, causing a runtime error.

## Root cause

`author/carton/build.pl` uses `App::FatPacker::Simple`, which does **no dependency tracing**. It simply collects every `.pm` under the `local/` directory (minus the `-e` excludes) and fat-packs them. So a module ends up in the generated `carton` only if it physically exists under `local/lib/perl5/`.

`CPAN::Meta` is only a *transitive* dependency of Carton (via `Menlo` and `Module::CPANfile`) and is **not** listed directly in the cpanfile. Meanwhile, the base perl built in the `Dockerfile` (Perl-Build) bootstraps a copy of `CPAN::Meta` into the perl core lib. Because that copy already satisfies the transitive version requirement, `carton install` (i.e. `make update`) considers it satisfied and **never installs `CPAN::Meta` into `local/`** — and drops the `CPAN-Meta` distribution from the regenerated `cpanfile.snapshot`. As a result, the next fat-pack produces a `carton` without `CPAN::Meta`.

This was reproduced end-to-end in the real build environment (Alpine + perl 5.8.8): after a plain `carton install`, `local/lib/perl5/CPAN/Meta.pm` is absent and `CPAN-Meta-2.150013` disappears from the snapshot.

## Fix

Require `CPAN::Meta` explicitly in `author/carton/cpanfile`, pinned above the base perl's bundled version so that `carton install` is forced to install it into `local/` where it gets fat-packed:

```perl
requires 'CPAN::Meta', '==2.150013';
```

The pin is kept at `2.150013` on purpose: `2.150015+` requires `CPAN::Meta::Requirements 2.145`, which does not support perl 5.8 (the cpanfile already pins `CPAN::Meta::Requirements` to `2.140` for the same reason).

Note: deleting `CPAN::Meta` from the base perl is **not** a viable alternative — the base `carton` command itself loads `CPAN::Meta` (via `Carton::Dist`), so removing it breaks `carton install`.

## Verification

Reproduced in Docker (Alpine + perl 5.8.8), with the updated cpanfile against the current committed snapshot:

- `carton install --deployment` succeeds
- `build.pl` fat-pack succeeds and the generated `carton` now contains `CPAN::Meta`, `CPAN::Meta::Converter`, `CPAN::Meta::Validator`, `Parse::CPAN::Meta`, etc.
- The generated `carton` runs (`carton v1.0.35`)

## Notes

The committed `cpanfile.snapshot` already lists `CPAN-Meta-2.150013`, so deployment builds keep working without regenerating it. This change primarily prevents `make update` from silently dropping `CPAN-Meta` from the snapshot again. Regenerating the snapshot is intentionally left out of this PR since it would bump many unrelated modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a pinned CPAN::Meta dependency to support consistent package installation.
  * Documented compatibility and installation requirements for the dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->