### PR TITLE
Require CPAN::Meta in author/cpanm to keep it fat-packed

### DIFF
--- a/author/cpanm/cpanfile
+++ b/author/cpanm/cpanfile
@@ -7,7 +7,15 @@ requires 'App::FatPacker::Simple', '==0.09';
 # https://github.com/miyagawa/cpanminus/issues/455
 requires 'CPAN::Common::Index', 0.006;
 requires 'CPAN::DistnameInfo';
-requires 'CPAN::Meta', '2.132830';
+# CPAN::Meta is only a transitive dependency here, and the base perl image already
+# bundles a copy (installed alongside Carton), so `carton install` (make update)
+# considers the minimum requirement satisfied and never installs it into local/.
+# App::FatPacker::Simple fatpacks only what is under local/, so the generated cpanm
+# would be missing CPAN::Meta (and the Parse/CPAN/Meta.pm patch would have no file to
+# patch). Pin it above the base perl's bundled version to force it into local/ so it
+# gets fat-packed. 2.150015+ needs CPAN::Meta::Requirements 2.145, which doesn't
+# support perl 5.8, so keep it at 2.150014.
+requires 'CPAN::Meta', '==2.150014';
 requires 'CPAN::Meta::Check';
 requires 'CPAN::Meta::Requirements', '==2.140'; # 2.141 doesn't support perl 5.8.
 requires 'CPAN::Meta::YAML';


### PR DESCRIPTION
## Background / 背景

The cpanm fat-pack update job (`update cpanm` workflow) for `author/cpanm` was failing.

`author/cpanm` の cpanm fat-pack 更新ジョブ（`update cpanm` ワークフロー）が失敗していました。

Failing log / 失敗ログ: https://github.com/shogo82148/actions-setup-perl/actions/runs/34345963528/job/102447496131

```
! Couldn't find module or a distribution CPAN::Meta (2.132830)
! Couldn't find module or a distribution Parse::CPAN::Meta
...
|--- Parse/CPAN/Meta.pm
No file to patch.  Skipping patch.
make: *** [Makefile:34: .deps.exists] Error 1
```

## Cause / 原因

**English**

1. The `Dockerfile` installs Carton via `cpanmin.us`, which pulls CPAN::Meta (the current CPAN release, 2.150010) into the base image's perl as a transitive dependency.
2. `cpanfile` only specified `requires 'CPAN::Meta', '2.132830'`, a **minimum** version, which is already satisfied by 2.150010.
3. `make update` (`carton install`, regenerating the snapshot without the existing one) therefore treats CPAN::Meta as already satisfied and never installs it into `local/` nor records it in the new `cpanfile.snapshot`.
4. The following `carton install --deployment` in `make deps` then fails to lay down `Parse::CPAN::Meta` and friends, so the subsequent patch to `Parse/CPAN/Meta.pm` fails with `No file to patch`, exiting with code 2.

This is the same root cause as the CPAN::Meta fat-pack gap fixed for `author/carton` (commit b7c73d7a): `App::FatPacker::Simple` fat-packs only what lives under `local/`, so anything not installed there is missing from the generated script.

**日本語**

1. `Dockerfile` が `cpanmin.us` で Carton を入れる際、その依存として CPAN::Meta（CPAN 最新の 2.150010）がベースイメージの perl に入る。
2. `cpanfile` の指定は `requires 'CPAN::Meta', '2.132830'` という**最小**バージョン指定なので、2.150010 で満たされてしまう。
3. `make update`（`carton install`、既存 snapshot を渡さず再生成）が CPAN::Meta を「充足済み」と判断し、`local/` にも新しい `cpanfile.snapshot` にも入れない。
4. 続く `make deps` の `carton install --deployment` で `Parse::CPAN::Meta` 等がインストールされず、直後の `Parse/CPAN/Meta.pm` へのパッチが `No file to patch` で失敗し exit 2。

これは `author/carton` の CPAN::Meta 同梱漏れ（commit b7c73d7a）と同じ根本原因です。`App::FatPacker::Simple` は `local/` 配下のみ fat-pack するため、そこに入らないモジュールは生成物から漏れます。

## Fix / 修正

**English**

Apply the same fix used for carton. Pin CPAN::Meta above the version bundled in the base image, using `==`, so `carton install` always installs it into `local/` and it gets fat-packed.

- `requires 'CPAN::Meta', '2.132830';` → `requires 'CPAN::Meta', '==2.150014';`
- The version is aligned with the current `cpanfile.snapshot`, which already records and fat-packs 2.150014 (so the snapshot is unchanged). It also satisfies the constraint that 2.150015+ requires CPAN::Meta::Requirements 2.145, which does not support perl 5.8.

**日本語**

carton と同じ対策を適用します。CPAN::Meta を、ベースイメージが同梱するバージョンより上に `==` でピン留めし、`carton install` が必ず `local/` にインストールして fat-pack されるようにします。

- `requires 'CPAN::Meta', '2.132830';` → `requires 'CPAN::Meta', '==2.150014';`
- バージョンは現行 `cpanfile.snapshot` が既に記録・fat-pack 実績のある `2.150014` に合わせています（snapshot の変更なし）。`2.150015+` は CPAN::Meta::Requirements 2.145 を要求し perl 5.8 非対応、という制約も満たします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)